### PR TITLE
ci: pin python patch version

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2022]
-        python: ["3.10"]
+        python: ["3.10.8"]
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022]
-        python: ["3.10"]
+        python: ["3.10.8"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- pin Python matrix version to 3.10.8 in CI workflows

## Testing
- `pre-commit run --files .github/workflows/ci-pull-request.yml .github/workflows/ci-push.yml`
- `python3 -m pytest -q` *(fails: assertion errors in integration tests such as `tests/integration/test_crawl_real_urls.py::test_crawl_17track`)*

------
https://chatgpt.com/codex/tasks/task_e_68c801aaa8788326a852c098c300765a