### PR TITLE
chore: schedule issue triage daily

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -2,7 +2,7 @@ name: '📋 Gemini Scheduled Issue Triage'
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs every hour
+    - cron: '0 0 * * *' # Runs daily at midnight
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
## Summary
- reduce scheduled Gemini triage frequency to once per day

## Testing
- `/root/.pyenv/versions/3.10.17/bin/pre-commit run --files .github/workflows/gemini-scheduled-triage.yml`
- `PYENV_VERSION=3.10.17 pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c807b3be24832694668aec8675b565