### PR TITLE
Trigger Claude workflow on pull requests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created, edited]
   pull_request_review_comment:
@@ -13,6 +15,9 @@ on:
 jobs:
   claude:
     if: |
+      (
+        github.event_name == 'pull_request'
+      ) ||
       (
         github.event_name == 'issue_comment' &&
         contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.comment.author_association) &&


### PR DESCRIPTION
## Summary
- run Claude Code workflow on `pull_request` events for automatic reviews

## Testing
- `pre-commit run --files .github/workflows/claude.yml`
- `PYTHONPATH=. pytest` *(fails: assertion errors in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c757c4c8326b790179ae2497cde