### PR TITLE
chore: refresh root certs in integration CI

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -65,6 +65,13 @@ jobs:
       - name: Fetch Camoufox resources
         run: camoufox fetch
 
+      - name: Update root certificates
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          certutil -generateSSTFromWU roots.sst
+          Import-Certificate -FilePath roots.sst -CertStoreLocation Cert:\LocalMachine\Root
+
       - name: Run integration tests
         run: python -m pytest -q -m "integration" --disable-warnings --maxfail=1
 


### PR DESCRIPTION
## Summary
- refresh Windows root certificates during integration workflow to avoid SEC_ERROR_UNKNOWN_ISSUER errors

## Testing
- `pre-commit run --files .github/workflows/ci-pull-request.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c811ecde188326aaa00348392e273a