### PR TITLE
chore: standardize GitHub workflow names

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI - Pull request (Unit + Integration)
+name: '🧪 CI - Pull Request (Unit + Integration)'
 
 on:
   pull_request:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,4 +1,4 @@
-name: CI - Push (Unit)
+name: '🧪 CI - Push (Unit)'
 
 on:
   push:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-name: Claude Code
+name: '🤖 Claude'
 
 on:
   pull_request:

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,4 +1,4 @@
-name: '🔀 Gemini Dispatch'
+name: '🪐 Gemini - Dispatch'
 
 on:
   pull_request_review_comment:

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -1,4 +1,4 @@
-name: '▶️ Gemini Invoke'
+name: '🪐 Gemini - Invoke'
 
 on:
   workflow_call:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,4 +1,4 @@
-name: '🔎 Gemini Review'
+name: '🪐 Gemini - Review'
 
 on:
   workflow_call:

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -1,4 +1,4 @@
-name: '📋 Gemini Scheduled Issue Triage'
+name: '🪐 Gemini - Scheduled Issue Triage'
 
 on:
   schedule:

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -1,4 +1,4 @@
-name: '🔀 Gemini Triage'
+name: '🪐 Gemini - Triage'
 
 on:
   workflow_call:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,4 +1,4 @@
-name: opencode
+name: '🔓 Opencode'
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary
- prefix CI workflows with 🧪 and clarify pull request label
- rename Claude Code workflow to 🤖 Claude
- standardize Gemini workflows with 🪐 Gemini - <functionality> names and add 🔓 Opencode

## Testing
- `PYENV_VERSION=3.10.17 python -m pytest` *(fails: scrapling module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c81cc095488326a4a4e4fe40abca85