### PR TITLE
fix: enable Claude auto review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -197,7 +197,7 @@ jobs:
           prompt: |
               REPO: ${{ github.repository }}
               EVENT: ${{ github.event_name }}
-              PR NUMBER: ${{ github.event.pull_request.number || '' }}
+              PR NUMBER: ${{ github.event.pull_request && github.event.pull_request.number || '' }}
               ISSUE NUMBER: ${{ github.event.issue.number || '' }}
 
               Act as a helpful GitHub assistant for the current event.


### PR DESCRIPTION
## Summary
- configure Claude GitHub Action with a general-purpose prompt that handles pull requests, issues, and comments
- permit both PR and issue comment tools for flexible interaction

## Testing
- `pre-commit run --files .github/workflows/claude.yml`
- `.venv/bin/python -m pytest` *(fails: 10 failed, 195 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c81bf938948326b9ff15d76b90e9c0