### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FastAPI Project Template
+# Scrapling FastAPI
 
-A scalable FastAPI project template with a layered architecture, Docker support, and testing framework.
+A scalable FastAPI project with a layered architecture and testing framework.
 
 ## Project Overview
 
@@ -9,7 +9,7 @@ This project provides a robust and extensible FastAPI service designed for advan
 ## Project Structure
 
 ```
-project-template/
+scrapling-fastapi/
 ├── app/                    # Main application package
 │   ├── __init__.py         # Package initializer
 │   ├── main.py             # FastAPI application entry point
@@ -29,8 +29,6 @@ project-template/
 │   ├── middleware/         # Middleware tests
 │   ├── schemas/            # Schema tests
 │   └── services/           # Service tests
-├── docker-compose.yml      # Docker Compose configuration
-├── Dockerfile              # Docker image definition
 ├── requirements.txt        # Python dependencies
 ├── .env                    # Environment variables
 ├── .gitignore              # Git ignore rules
@@ -40,9 +38,8 @@ project-template/
 
 ## Features
 
-- **FastAPI**: Modern, fast (high-performance) web framework for building APIs with Python 3.7+ based on standard Python type hints.
+- **FastAPI**: Modern, fast (high-performance) web framework for building APIs with Python 3.10+ based on standard Python type hints.
 - **Layered Architecture**: Separation of concerns with distinct layers for API, core, middleware, schemas, and services.
-- **Docker Support**: Containerized application for easy deployment and scalability.
 - **Environment Configuration**: Configuration management through environment variables.
 - **Testing Framework**: Pytest integration for comprehensive testing.
 - **Health Checks**: Built-in health check endpoint for monitoring.
@@ -54,8 +51,7 @@ project-template/
 
 ## Prerequisites
 
-- Python 3.7+
-- Docker (optional, for containerized deployment)
+- Python 3.10+
 - pip (Python package installer)
 
 ## Installation
@@ -66,7 +62,7 @@ project-template/
 
    ```bash
    git clone <repository-url>
-   cd project-template
+   cd scrapling-fastapi
    ```
 2. Create a virtual environment:
 
@@ -86,31 +82,34 @@ project-template/
    cp .env.example .env
    ```
 
-### Using Docker
-
-1. Build and run with Docker Compose:
-
-   ```bash
-   docker-compose up --build
-   ```
-2. The application will be available at `http://localhost:8001`
-
 ## Running the Application
+
+Run the FastAPI app locally:
+
+```bash
+python -m uvicorn app.main:app --host 0.0.0.0 --port 5681 --reload
+```
 
 For detailed instructions on running the application, see [RUN.md](RUN.md).
 
 ## Testing
 
-Run the test suite using python -m pytest:
+Run all tests:
 
 ```bash
 python -m pytest
 ```
 
-Or with verbose output:
+Unit tests only:
 
 ```bash
-python -m pytest -v
+python -m pytest -m "not integration"
+```
+
+Integration tests only:
+
+```bash
+python -m pytest -m integration
 ```
 
 ## Extending the Template
@@ -148,16 +147,6 @@ Contains business logic and service implementations, further organized into:
 - **Common Layer (`app/services/common/`)**: Provides shared utilities, interfaces, and base components.
 - **Crawler Layer (`app/services/crawler/`)**: Manages web crawling logic, including retry mechanisms, proxy handling, and specific vertical implementations.
 - **TikTok Layer (`app/services/tiktok/`)**: Contains services specific to TikTok, such as session management and search functionalities.
-
-## Docker Configuration
-
-The template includes a multi-stage Dockerfile and docker-compose.yml for containerized deployment:
-
-- Uses Python 3.10 Bookworm as base image
-- Installs dependencies in a separate layer for better caching
-- Exposes port 8001
-- Includes health check configuration
-- Uses environment variables for configuration
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- rename project to Scrapling FastAPI and drop Docker references
- document Python 3.10+ requirement and quick uvicorn start command
- expand testing instructions for all, unit, and integration tests

## Testing
- `python -m pytest` *(fails: 10 failed, 195 passed)*
- `python -m pytest -m "not integration"`
- `python -m pytest -m integration` *(fails: 10 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c8205faf1c8326ac26c5c75c61a85e