### PR TITLE
Add configuration tests for environment variables and fallback settings

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+import types
+
+from app.core import config
+
+
+def test_get_settings_env_vars(monkeypatch):
+    """Ensure environment variables override defaults using pydantic settings."""
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("PORT", "1234")
+    importlib.reload(config)
+    config.get_settings.cache_clear()
+    settings = config.get_settings()
+    assert settings.log_level == "DEBUG"
+    assert settings.port == 1234
+
+
+def test_get_settings_fallback(monkeypatch):
+    """Simulate missing pydantic_settings to trigger fallback Settings class."""
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+    real_ps = sys.modules.get("pydantic_settings")
+    dummy = types.ModuleType("pydantic_settings")
+    dummy.BaseSettings = None
+    dummy.SettingsConfigDict = dict
+    monkeypatch.setitem(sys.modules, "pydantic_settings", dummy)
+    importlib.reload(config)
+    config.get_settings.cache_clear()
+    settings = config.get_settings()
+    assert settings.log_level == "INFO"
+    assert settings.port == 8000
+    sys.modules["pydantic_settings"] = real_ps
+    importlib.reload(config)


### PR DESCRIPTION
## Summary
- add tests asserting environment variable overrides in `get_settings`
- cover fallback `Settings` path when `pydantic_settings` is unavailable

## Testing
- `pre-commit run --files tests/core/test_config.py`
- `pytest --noconftest tests/core/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c82aa084548326b5bef48707ad0ebd