### PR TITLE
test: add window size parsing tests

### DIFF
--- a/tests/services/browser/test_camoufox_args_builder.py
+++ b/tests/services/browser/test_camoufox_args_builder.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.services.common.browser.camoufox import CamoufoxArgsBuilder
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1280x720", (1280, 720)),
+        ("800,600", (800, 600)),
+        ("1920x1080", (1920, 1080)),
+        ("2560x1440", (2560, 1440)),
+        ("3840x2160", (3840, 2160)),
+    ],
+)
+def test_parse_window_size_valid(value, expected):
+    """Valid window size strings should parse to integer tuples."""
+    assert CamoufoxArgsBuilder._parse_window_size(value) == expected
+
+
+@pytest.mark.parametrize("value", ["abc", "100", ""])
+def test_parse_window_size_invalid(value):
+    """Invalid window size strings should return None."""
+    assert CamoufoxArgsBuilder._parse_window_size(value) is None


### PR DESCRIPTION
## Summary
- test CamoufoxArgsBuilder._parse_window_size with full HD, 2K and 4K resolutions
- ensure invalid window size strings return None

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest --noconftest tests/services/browser/test_camoufox_args_builder.py -q`
- `PYENV_VERSION=3.10.17 pre-commit run --files tests/services/browser/test_camoufox_args_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68c82ac009448326b823220b9bcd7f96