### PR TITLE
Add test for WaitForUserCloseAction

### DIFF
--- a/tests/services/browser/test_wait_for_close.py
+++ b/tests/services/browser/test_wait_for_close.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.browser.actions.wait_for_close import WaitForUserCloseAction
+
+
+class DummyCloseError(Exception):
+    """Dummy exception to simulate failures from wait_for_event."""
+
+
+@pytest.fixture
+def mocked_page():
+    page = MagicMock()
+    page.bring_to_front = MagicMock()
+    page.wait_for_event = MagicMock(side_effect=DummyCloseError("boom"))
+    page.configure_mock(context=None)
+    return page
+
+
+def test_wait_for_user_close_action_returns_page_on_exception(mocked_page):
+    action = WaitForUserCloseAction()
+
+    result = action(mocked_page)
+
+    mocked_page.bring_to_front.assert_called_once_with()
+    mocked_page.wait_for_event.assert_called_once_with("close")
+    assert result is mocked_page


### PR DESCRIPTION
## Summary
- add a unit test for WaitForUserCloseAction covering wait_for_event exceptions
- ensure the action still returns the provided page object

## Testing
- pytest tests/services/browser/test_wait_for_close.py *(fails: pyenv reports Python 3.10.8 is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c834b6002083268ceacbe4cd6fbd49