### PR TITLE
fix: keep GEMINI trigger token

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -45,7 +45,7 @@ jobs:
   dispatch:
     # For PRs: only if not from a fork
     # For comments: only if message starts with an accepted token
-    #   (Gemini, GEMINI, @gemini-cli, /gemini) and author is OWNER/MEMBER/COLLABORATOR
+    #   (@gemini, @gemini-cli, /gemini, GEMINI) and author is OWNER/MEMBER/COLLABORATOR
     # For issues: only on open/reopen
     if: |-
       (
@@ -55,9 +55,9 @@ jobs:
         github.event.sender.type == 'User' &&
         (
           startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') ||
-          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, 'Gemini') ||
-          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, 'GEMINI') ||
-          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '/gemini')
+          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini') ||
+          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '/gemini') ||
+          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, 'GEMINI')
         ) &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
       ) || (
@@ -105,9 +105,9 @@ jobs:
               core.setOutput('additional_context', additionalContext);
             } else if (request.startsWith("@gemini-cli /triage")) {
               core.setOutput('command', 'triage');
-            } else if (request.startsWith("@gemini-cli") || request.startsWith("Gemini") || request.startsWith("GEMINI") || request.startsWith("/gemini")) {
+            } else if (request.startsWith("@gemini-cli") || request.startsWith("@gemini") || request.startsWith("/gemini") || request.startsWith("GEMINI")) {
               core.setOutput('command', 'invoke');
-              const tokens = ["@gemini-cli", "Gemini", "GEMINI", "/gemini"];
+              const tokens = ["@gemini-cli", "@gemini", "/gemini", "GEMINI"];
               const matched = tokens.find((t) => request.startsWith(t));
               const additionalContext = (matched ? request.slice(matched.length) : request).trim();
               core.setOutput('additional_context', additionalContext);


### PR DESCRIPTION
## Summary
- switch comment trigger from `Gemini` to `@gemini` while retaining support for the all-caps `GEMINI`

## Testing
- Attempted `pre-commit run --files .github/workflows/gemini-dispatch.yml` *(not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8285d06808326824aa555a4fe1c48