### PR TITLE
Expand router route coverage in test

### DIFF
--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,0 +1,23 @@
+from fastapi.routing import APIRoute
+
+from app.api.routes import router
+
+
+EXPECTED_PATHS = {
+    "/health",
+    "/crawl",
+    "/crawl/dpd",
+    "/crawl/auspost",
+    "/browse",
+    "/tiktok/session",
+    "/tiktok/search",
+}
+
+
+def test_routes_include_expected_paths():
+    registered_paths = {
+        route.path for route in router.routes if isinstance(route, APIRoute)
+    }
+
+    missing = EXPECTED_PATHS - registered_paths
+    assert not missing, f"Missing expected routes: {sorted(missing)}"


### PR DESCRIPTION
## Summary
- ensure the aggregated API router test checks crawl derivatives and TikTok search routes

## Testing
- PYENV_VERSION=3.10.17 python -m pytest tests/api/test_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68c834cb4bdc8326a00b46a8e00c636a