### PR TITLE
Refactor TikTok session management

### DIFF
--- a/app/services/tiktok/actions.py
+++ b/app/services/tiktok/actions.py
@@ -1,0 +1,14 @@
+"""Helper utilities for dispatching TikTok executor actions."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.tiktok.tiktok_executor import TiktokExecutor
+
+
+async def dispatch_action(executor: TiktokExecutor, action: str, **kwargs: Any) -> Any:
+    """Invoke an action on the provided executor."""
+    if not hasattr(executor, action):
+        raise AttributeError(f"Unknown action: {action}")
+    method = getattr(executor, action)
+    return await method(**kwargs)

--- a/app/services/tiktok/service.py
+++ b/app/services/tiktok/service.py
@@ -1,16 +1,14 @@
-"""
-TikTok session service
-"""
-import os
+"""TikTok session service"""
+
 import logging
-import uuid
 from typing import Dict, Any, Optional, Union, List
-from datetime import datetime, timedelta
-from app.services.tiktok.tiktok_executor import TiktokExecutor
-from app.services.tiktok.utils.login_detection import LoginDetector
-from app.schemas.tiktok import TikTokSessionRequest, TikTokSessionResponse, TikTokLoginState, TikTokSessionConfig
+
 from app.core.config import get_settings
+from app.schemas.tiktok import TikTokSessionRequest, TikTokSessionResponse
+from app.services.tiktok.actions import dispatch_action
 from app.services.tiktok.search_service import TikTokSearchService
+from app.services.tiktok.session_manager import TikTokSessionManager, TikTokSessionMetadata
+from app.services.tiktok.tiktok_executor import TiktokExecutor
 
 
 class TiktokService:
@@ -18,9 +16,26 @@ class TiktokService:
 
     def __init__(self):
         self.settings = get_settings()
-        self.active_sessions: Dict[str, TiktokExecutor] = {}
-        self.session_metadata: Dict[str, Dict[str, Any]] = {}
         self.logger = logging.getLogger(__name__)
+        self.session_manager = TikTokSessionManager(self.settings, logger=self.logger)
+
+    @property
+    def active_sessions(self) -> Dict[str, TiktokExecutor]:
+        """Expose active sessions dictionary for compatibility"""
+        return self.session_manager.active_sessions
+
+    @active_sessions.setter
+    def active_sessions(self, value: Dict[str, TiktokExecutor]) -> None:
+        self.session_manager.active_sessions = value
+
+    @property
+    def session_metadata(self) -> Dict[str, TikTokSessionMetadata]:
+        """Expose session metadata dictionary for compatibility"""
+        return self.session_manager.session_metadata
+
+    @session_metadata.setter
+    def session_metadata(self, value: Dict[str, TikTokSessionMetadata]) -> None:
+        self.session_manager.session_metadata = value
 
     async def create_session(
         self, request: TikTokSessionRequest, user_data_dir: Optional[str] = None, immediate_cleanup: bool = False
@@ -33,58 +48,9 @@ class TiktokService:
         Returns:
             TikTokSessionResponse: Session creation result
         """
-        session_id = str(uuid.uuid4())
-        try:
-            # Load TikTok configuration
-            config = await self._load_tiktok_config(user_data_dir)
-            # Create executor instance
-            executor = TiktokExecutor(config)
-            # Start browser session
-            await executor.start_session()
-            # Detect login state
-            login_state = await self._detect_login_state(executor, config.login_detection_timeout)
-            if login_state == TikTokLoginState.LOGGED_OUT:
-                # User not logged in - close session and return 409
-                await executor.cleanup()
-                return TikTokSessionResponse(
-                    status="error",
-                    message="Not logged in to TikTok",
-                    error_details={
-                        "code": "NOT_LOGGED_IN",
-                        "details": "User is not logged in to TikTok",
-                        "method": "dom_api_combo",
-                        "timeout": config.login_detection_timeout
-                    }
-                )
-            # Session created successfully
-            if not immediate_cleanup:
-                self.active_sessions[session_id] = executor
-                self.session_metadata[session_id] = {
-                    "created_at": datetime.now(),
-                    "last_activity": datetime.now(),
-                    "user_data_dir": executor.user_data_dir,
-                    "config": config,
-                    "login_state": login_state
-                }
-            response = TikTokSessionResponse(
-                status="success",
-                message="TikTok session established successfully"
-            )
-            # If immediate cleanup is requested, clean up now
-            if immediate_cleanup:
-                await executor.cleanup()
-            return response
-        except Exception as e:
-            await self._cleanup_session(session_id)
-            return TikTokSessionResponse(
-                status="error",
-                message="Failed to create TikTok session",
-                error_details={
-                    "code": "SESSION_CREATION_FAILED",
-                    "details": str(e),
-                    "method": "internal_error"
-                }
-            )
+        return await self.session_manager.create_session(
+            request, user_data_dir=user_data_dir, immediate_cleanup=immediate_cleanup
+        )
 
     async def has_active_session(self) -> bool:
         """
@@ -92,8 +58,6 @@ class TiktokService:
         Returns:
             bool: True if there is an active session, False otherwise
         """
-        # For now, we'll check if there are any active sessions
-        # In a more complex implementation, we might want to check session validity
         has_session = len(self.active_sessions) > 0
         self.logger.debug(
             f"[TiktokService] has_active_session called - current sessions: {len(self.active_sessions)}, "
@@ -107,12 +71,9 @@ class TiktokService:
         Returns:
             TiktokExecutor: The active session executor or None if no active session
         """
-        # For now, we'll return the first active session
-        # In a more complex implementation, we might want to select based on criteria
         session_count = len(self.active_sessions)
         self.logger.debug(f"[TiktokService] get_active_session called - available sessions: {session_count}")
         if self.active_sessions:
-            # Get the first session
             session_id = next(iter(self.active_sessions))
             self.logger.debug(f"[TiktokService] Returning active session: {session_id}")
             return self.active_sessions[session_id]
@@ -128,7 +89,6 @@ class TiktokService:
             f"sort_type: {sort_type}, recency_days: {recency_days}"
         )
 
-        # Check if there's an active session
         if not await self.has_active_session():
             self.logger.debug("[TiktokService] No active session found, returning error")
             return {
@@ -139,7 +99,6 @@ class TiktokService:
             }
 
         try:
-            # Execute search (search operates independently of sessions)
             self.logger.debug("[TiktokService] Creating TikTokSearchService and executing independent search")
             search_service = TikTokSearchService(self)
             result = await search_service.search(
@@ -153,7 +112,6 @@ class TiktokService:
         except Exception as e:
             self.logger.error(f"[TiktokService] Exception in search_tiktok: {e}", exc_info=True)
             return {"error": f"Search failed: {str(e)}"}
-    # Search helpers moved to app.services.tiktok.search_service
 
     async def close_session(self, session_id: str) -> bool:
         """
@@ -164,21 +122,7 @@ class TiktokService:
             bool: True if session was closed successfully
         """
         self.logger.debug(f"[TiktokService] Attempting to close session: {session_id}")
-        try:
-            if session_id not in self.active_sessions:
-                self.logger.warning(f"[TiktokService] Session {session_id} not found in active sessions")
-                return False
-            executor = self.active_sessions[session_id]
-            await executor.cleanup()
-            # Remove from active sessions
-            del self.active_sessions[session_id]
-            if session_id in self.session_metadata:
-                del self.session_metadata[session_id]
-            self.logger.debug(f"[TiktokService] Successfully closed session: {session_id}")
-            return True
-        except Exception as e:
-            self.logger.error(f"[TiktokService] Error closing session {session_id}: {e}", exc_info=True)
-            return False
+        return await self.session_manager.close_session(session_id)
 
     async def keep_alive(self, session_id: str) -> bool:
         """
@@ -188,19 +132,7 @@ class TiktokService:
         Returns:
             bool: True if session was found and kept alive
         """
-        try:
-            if session_id not in self.active_sessions:
-                return False
-            # Check if session is still active
-            executor = self.active_sessions[session_id]
-            if not await executor.is_still_active():
-                await self.close_session(session_id)
-                return False
-            # Update last activity time
-            self.session_metadata[session_id]["last_activity"] = datetime.now()
-            return True
-        except Exception:
-            return False
+        return await self.session_manager.keep_alive(session_id)
 
     async def get_session_info(self, session_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -211,24 +143,12 @@ class TiktokService:
             Dict with session information or None if not found
         """
         self.logger.debug(f"[TiktokService] Getting session info for: {session_id}")
-        try:
-            if session_id not in self.active_sessions:
-                self.logger.warning(f"[TiktokService] Session {session_id} not found")
-                return None
-            executor = self.active_sessions[session_id]
-            metadata = self.session_metadata[session_id]
-            self.logger.debug(f"[TiktokService] Session {session_id} metadata: {metadata}")
-            session_info = await executor.get_session_info()
-            result = {
-                **metadata,
-                **session_info,
-                "timeout_remaining": self._get_timeout_remaining(metadata)
-            }
+        info = await self.session_manager.get_session_info(session_id)
+        if info is None:
+            self.logger.warning(f"[TiktokService] Session {session_id} not found")
+        else:
             self.logger.debug(f"[TiktokService] Session {session_id} info retrieved successfully")
-            return result
-        except Exception as e:
-            self.logger.error(f"[TiktokService] Error getting session info for {session_id}: {e}", exc_info=True)
-            return None
+        return info
 
     async def perform_action(self, session_id: str, action: str, **kwargs) -> Dict[str, Any]:
         """
@@ -248,19 +168,18 @@ class TiktokService:
                 self.logger.warning(f"[TiktokService] Session {session_id} not found for action '{action}'")
                 return {"error": "Session not found"}
             executor = self.active_sessions[session_id]
-            # Update last activity
-            self.session_metadata[session_id]["last_activity"] = datetime.now()
-            self.logger.debug(f"[TiktokService] Updated last activity for session {session_id}")
-            # Perform the action
-            if hasattr(executor, action):
-                method = getattr(executor, action)
-                self.logger.debug(f"[TiktokService] Found method '{action}' on executor")
-                result = await method(**kwargs)
-                self.logger.debug(f"[TiktokService] Action '{action}' completed successfully")
-                return {"success": True, "result": result}
-            else:
-                self.logger.warning(f"[TiktokService] Unknown action '{action}' requested")
-                return {"error": f"Unknown action: {action}"}
+
+            metadata = self.session_metadata.get(session_id)
+            if metadata:
+                metadata.touch()
+                self.logger.debug(f"[TiktokService] Updated last activity for session {session_id}")
+
+            result = await dispatch_action(executor, action, **kwargs)
+            self.logger.debug(f"[TiktokService] Action '{action}' completed successfully")
+            return {"success": True, "result": result}
+        except AttributeError:
+            self.logger.warning(f"[TiktokService] Unknown action '{action}' requested")
+            return {"error": f"Unknown action: {action}"}
         except Exception as e:
             self.logger.error(
                 f"[TiktokService] Exception performing action '{action}' on session {session_id}: {e}",
@@ -276,81 +195,16 @@ class TiktokService:
         Returns:
             bool: True if session has timed out
         """
-        try:
-            if session_id not in self.session_metadata:
-                return True
-            metadata = self.session_metadata[session_id]
-            timeout_remaining = self._get_timeout_remaining(metadata)
-            return timeout_remaining <= 0
-        except Exception:
-            return True
-
-    async def _load_tiktok_config(self, user_data_dir: Optional[str] = None) -> TikTokSessionConfig:
-        """Load TikTok configuration from settings"""
-        # Use CAMOUFOX_USER_DATA_DIR for both master and clones directories
-        base_user_data_dir = self.settings.camoufox_user_data_dir or "./user_data"
-        # Headless policy:
-        # - Default aligns with global HEADLESS setting (settings.default_headless)
-        # - Unit tests (some) force headless
-        headless = bool(getattr(self.settings, "default_headless", True))
-        try:
-            # Detect pytest and only enable headless for unit tests path
-            current_test = os.environ.get("PYTEST_CURRENT_TEST", "")
-            norm = current_test.replace("\\", "/").lower()
-            if "/tests/unit/" in norm or "tests/unit/" in norm:
-                headless = True
-        except Exception:
-            headless = bool(getattr(self.settings, "default_headless", True))
-        return TikTokSessionConfig(
-            user_data_master_dir=base_user_data_dir,
-            user_data_clones_dir=base_user_data_dir,
-            write_mode_enabled=self.settings.tiktok_write_mode_enabled,
-            acquire_lock_timeout=30,
-            login_detection_timeout=self.settings.tiktok_login_detection_timeout,
-            max_session_duration=self.settings.tiktok_max_session_duration,
-            tiktok_url=self.settings.tiktok_url,
-            headless=headless
-        )
-
-    async def _detect_login_state(self, executor: TiktokExecutor, timeout: int) -> TikTokLoginState:
-        """Detect login state using the executor"""
-        if not executor.browser:
-            return TikTokLoginState.UNCERTAIN
-        detector = LoginDetector(executor.browser, await self._load_tiktok_config())
-        return await detector.detect_login_state(timeout)
-
-    def _get_timeout_remaining(self, metadata: Dict[str, Any]) -> int:
-        """Calculate timeout remaining for a session"""
-        created_at = metadata["created_at"]
-        last_activity = metadata["last_activity"]
-        max_duration = metadata["config"].max_session_duration
-        # Use the later of creation time or last activity
-        time_reference = max(created_at, last_activity)
-        timeout_at = time_reference + timedelta(seconds=max_duration)
-        now = datetime.now()
-        return max(0, int((timeout_at - now).total_seconds()))
+        return await self.session_manager.check_session_timeout(session_id)
 
     async def _cleanup_session(self, session_id: str) -> None:
         """Clean up session resources"""
-        try:
-            if session_id in self.active_sessions:
-                await self.close_session(session_id)
-        except Exception as e:
-            print(f"Error cleaning up session {session_id}: {e}")
+        await self.session_manager.cleanup_session(session_id)
 
     async def get_active_sessions(self) -> Dict[str, Dict[str, Any]]:
         """Get information about all active sessions"""
-        sessions_info = {}
-        for session_id in list(self.active_sessions.keys()):
-            session_info = await self.get_session_info(session_id)
-            if session_info:
-                sessions_info[session_id] = session_info
-            else:
-                # Session no longer active, clean it up
-                await self._cleanup_session(session_id)
-        return sessions_info
+        return await self.session_manager.get_active_sessions()
 
     async def cleanup_all_sessions(self) -> None:
         """Clean up all active sessions"""
-        for session_id in list(self.active_sessions.keys()):
-            await self._cleanup_session(session_id)
+        await self.session_manager.cleanup_all_sessions()

--- a/app/services/tiktok/session_manager.py
+++ b/app/services/tiktok/session_manager.py
@@ -1,0 +1,258 @@
+"""Session management utilities for TikTok service."""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from app.schemas.tiktok import (
+    TikTokLoginState,
+    TikTokSessionConfig,
+    TikTokSessionRequest,
+    TikTokSessionResponse,
+)
+from app.services.tiktok.tiktok_executor import TiktokExecutor
+from app.services.tiktok.utils.login_detection import LoginDetector
+
+
+@dataclass
+class TikTokSessionMetadata:
+    """Structured metadata describing an active TikTok session."""
+
+    user_data_dir: Optional[str]
+    config: TikTokSessionConfig
+    login_state: TikTokLoginState
+    created_at: datetime = field(default_factory=datetime.now)
+    last_activity: datetime = field(default_factory=datetime.now)
+
+    def touch(self) -> None:
+        """Update the last-activity timestamp for keep-alive events."""
+        self.last_activity = datetime.now()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize metadata to a dictionary for external consumers."""
+        return {
+            "created_at": self.created_at,
+            "last_activity": self.last_activity,
+            "user_data_dir": self.user_data_dir,
+            "config": self.config,
+            "login_state": self.login_state,
+        }
+
+    def timeout_remaining(self) -> int:
+        """Return remaining session duration in seconds."""
+        time_reference = max(self.created_at, self.last_activity)
+        timeout_at = time_reference + timedelta(seconds=self.config.max_session_duration)
+        now = datetime.now()
+        return max(0, int((timeout_at - now).total_seconds()))
+
+
+class TikTokSessionManager:
+    """Encapsulates lifecycle management for TikTok sessions."""
+
+    def __init__(self, settings: Any, logger: Optional[logging.Logger] = None):
+        self.settings = settings
+        self.logger = logger or logging.getLogger(__name__)
+        self.active_sessions: Dict[str, TiktokExecutor] = {}
+        self.session_metadata: Dict[str, TikTokSessionMetadata] = {}
+
+    async def create_session(
+        self,
+        request: TikTokSessionRequest,
+        user_data_dir: Optional[str] = None,
+        immediate_cleanup: bool = False,
+    ) -> TikTokSessionResponse:
+        """Create a TikTok session and register it as active."""
+        _ = request  # Request body currently unused; kept for future extensions.
+        session_id = str(uuid.uuid4())
+        try:
+            config = await self._load_tiktok_config(user_data_dir)
+            executor = TiktokExecutor(config)
+            await executor.start_session()
+            login_state = await self._detect_login_state(executor, config)
+            if login_state == TikTokLoginState.LOGGED_OUT:
+                await executor.cleanup()
+                return TikTokSessionResponse(
+                    status="error",
+                    message="Not logged in to TikTok",
+                    error_details={
+                        "code": "NOT_LOGGED_IN",
+                        "details": "User is not logged in to TikTok",
+                        "method": "dom_api_combo",
+                        "timeout": config.login_detection_timeout,
+                    },
+                )
+
+            if not immediate_cleanup:
+                executor.session_id = session_id
+                self.active_sessions[session_id] = executor
+                self.session_metadata[session_id] = TikTokSessionMetadata(
+                    user_data_dir=executor.user_data_dir,
+                    config=config,
+                    login_state=login_state,
+                )
+
+            response = TikTokSessionResponse(
+                status="success",
+                message="TikTok session established successfully",
+            )
+
+            if immediate_cleanup:
+                await executor.cleanup()
+
+            return response
+        except Exception as exc:  # pragma: no cover - safeguard for unexpected failures
+            await self._cleanup_session(session_id)
+            return TikTokSessionResponse(
+                status="error",
+                message="Failed to create TikTok session",
+                error_details={
+                    "code": "SESSION_CREATION_FAILED",
+                    "details": str(exc),
+                    "method": "internal_error",
+                },
+            )
+
+    def has_active_session(self) -> bool:
+        """Return True when at least one active session exists."""
+        return bool(self.active_sessions)
+
+    def get_active_session(self) -> Optional[TiktokExecutor]:
+        """Return the first available active session executor, if any."""
+        if self.active_sessions:
+            session_id = next(iter(self.active_sessions))
+            self.logger.debug(
+                f"[TikTokSessionManager] Returning active session with id: {session_id}"
+            )
+            return self.active_sessions[session_id]
+        return None
+
+    async def close_session(self, session_id: str) -> bool:
+        """Close and unregister an active session."""
+        try:
+            executor = self.active_sessions.pop(session_id, None)
+            if not executor:
+                self.logger.warning(
+                    f"[TikTokSessionManager] Session {session_id} not found in active sessions"
+                )
+                self.session_metadata.pop(session_id, None)
+                return False
+
+            await executor.cleanup()
+            self.session_metadata.pop(session_id, None)
+            self.logger.debug(
+                f"[TikTokSessionManager] Successfully closed session: {session_id}"
+            )
+            return True
+        except Exception as exc:
+            self.logger.error(
+                f"[TikTokSessionManager] Error closing session {session_id}: {exc}",
+                exc_info=True,
+            )
+            return False
+
+    async def keep_alive(self, session_id: str) -> bool:
+        """Refresh metadata for an active session to prevent timeouts."""
+        executor = self.active_sessions.get(session_id)
+        metadata = self.session_metadata.get(session_id)
+        if not executor or not metadata:
+            return False
+
+        if not await executor.is_still_active():
+            await self.close_session(session_id)
+            return False
+
+        metadata.touch()
+        return True
+
+    async def get_session_info(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return merged metadata and executor info for a session."""
+        executor = self.active_sessions.get(session_id)
+        metadata = self.session_metadata.get(session_id)
+        if not executor or not metadata:
+            return None
+
+        session_info = await executor.get_session_info()
+        details = metadata.to_dict()
+        details["timeout_remaining"] = metadata.timeout_remaining()
+        return {**details, **session_info}
+
+    async def check_session_timeout(self, session_id: str) -> bool:
+        """Return True if the session has expired based on inactivity."""
+        metadata = self.session_metadata.get(session_id)
+        if not metadata:
+            return True
+        return metadata.timeout_remaining() <= 0
+
+    async def get_active_sessions(self) -> Dict[str, Dict[str, Any]]:
+        """Return details for all active sessions."""
+        sessions: Dict[str, Dict[str, Any]] = {}
+        for session_id in list(self.active_sessions.keys()):
+            info = await self.get_session_info(session_id)
+            if info:
+                sessions[session_id] = info
+            else:
+                await self._cleanup_session(session_id)
+        return sessions
+
+    async def cleanup_all_sessions(self) -> None:
+        """Cleanup every registered session."""
+        for session_id in list(self.active_sessions.keys()):
+            await self._cleanup_session(session_id)
+
+    async def cleanup_session(self, session_id: str) -> None:
+        """Expose cleanup helper for selective session teardown."""
+        await self._cleanup_session(session_id)
+
+    async def _cleanup_session(self, session_id: str) -> None:
+        """Internal helper ensuring a session is torn down."""
+        try:
+            executor = self.active_sessions.pop(session_id, None)
+            if executor:
+                try:
+                    await executor.cleanup()
+                finally:
+                    self.session_metadata.pop(session_id, None)
+        except Exception as exc:
+            self.logger.error(
+                f"[TikTokSessionManager] Error cleaning up session {session_id}: {exc}",
+                exc_info=True,
+            )
+
+    async def _load_tiktok_config(
+        self, user_data_dir: Optional[str] = None
+    ) -> TikTokSessionConfig:
+        """Recreate configuration logic for TikTok sessions."""
+        base_user_data_dir = self.settings.camoufox_user_data_dir or "./user_data"
+        headless = bool(getattr(self.settings, "default_headless", True))
+        try:
+            current_test = os.environ.get("PYTEST_CURRENT_TEST", "")
+            norm = current_test.replace("\\", "/").lower()
+            if "/tests/unit/" in norm or "tests/unit/" in norm:
+                headless = True
+        except Exception:
+            headless = bool(getattr(self.settings, "default_headless", True))
+
+        del user_data_dir  # User data directories currently share the same base path.
+        return TikTokSessionConfig(
+            user_data_master_dir=base_user_data_dir,
+            user_data_clones_dir=base_user_data_dir,
+            write_mode_enabled=self.settings.tiktok_write_mode_enabled,
+            acquire_lock_timeout=30,
+            login_detection_timeout=self.settings.tiktok_login_detection_timeout,
+            max_session_duration=self.settings.tiktok_max_session_duration,
+            tiktok_url=self.settings.tiktok_url,
+            headless=headless,
+        )
+
+    async def _detect_login_state(
+        self, executor: TiktokExecutor, config: TikTokSessionConfig
+    ) -> TikTokLoginState:
+        """Detect login state using the executor and provided config."""
+        if not executor.browser:
+            return TikTokLoginState.UNCERTAIN
+        detector = LoginDetector(executor.browser, config)
+        return await detector.detect_login_state(config.login_detection_timeout)

--- a/tests/services/tiktok/test_tiktok_search_service.py
+++ b/tests/services/tiktok/test_tiktok_search_service.py
@@ -3,6 +3,9 @@ Unit tests for TikTok Search Service
 """
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
+
+from app.schemas.tiktok import TikTokLoginState
+from app.services.tiktok.session_manager import TikTokSessionMetadata
 from app.services.tiktok.service import TiktokService
 from app.services.tiktok.tiktok_executor import TiktokExecutor
 
@@ -27,13 +30,11 @@ class TestTikTokSearchService:
         """Test TikTok search with active session"""
         # Set up mock session
         tiktok_service.active_sessions["test_session"] = mock_executor
-        tiktok_service.session_metadata["test_session"] = {
-            "created_at": Mock(),
-            "last_activity": Mock(),
-            "user_data_dir": "/tmp/test",
-            "config": Mock(),
-            "login_state": "logged_in"
-        }
+        tiktok_service.session_metadata["test_session"] = TikTokSessionMetadata(
+            user_data_dir="/tmp/test",
+            config=Mock(),
+            login_state=TikTokLoginState.LOGGED_IN,
+        )
 
         # Mock the search_tiktok method to return test data
         with patch.object(tiktok_service, 'get_active_session', new=AsyncMock(return_value=mock_executor)):
@@ -50,13 +51,11 @@ class TestTikTokSearchService:
         """Test TikTok search with multiple queries"""
         # Set up mock session
         tiktok_service.active_sessions["test_session"] = mock_executor
-        tiktok_service.session_metadata["test_session"] = {
-            "created_at": Mock(),
-            "last_activity": Mock(),
-            "user_data_dir": "/tmp/test",
-            "config": Mock(),
-            "login_state": "logged_in"
-        }
+        tiktok_service.session_metadata["test_session"] = TikTokSessionMetadata(
+            user_data_dir="/tmp/test",
+            config=Mock(),
+            login_state=TikTokLoginState.LOGGED_IN,
+        )
 
         # Mock the search_tiktok method to return test data
         with patch.object(tiktok_service, 'get_active_session', new=AsyncMock(return_value=mock_executor)):


### PR DESCRIPTION
## Summary
- add a TikTok session manager module with structured metadata and lifecycle helpers
- update the service to delegate session handling to the manager and reuse a shared action dispatcher
- adjust TikTok search service tests to use the new session metadata dataclass

## Testing
- `PYTHONPATH=. pytest tests/services/tiktok/test_tiktok_search_service.py` *(fails: missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c849ed1d2483269f6bcfa1797f75ed