### PR TITLE
Enhance Gemini simple workflow automation

### DIFF
--- a/.github/workflows/gemini-simple.yml
+++ b/.github/workflows/gemini-simple.yml
@@ -11,29 +11,33 @@ on:
 jobs:
   gemini:
     if: |
+      secrets.GEMINI_API_KEY != '' &&
       (
-        github.event_name == 'pull_request'
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
         (
-          startsWith(github.event.comment.body, 'Gemini') ||
-          startsWith(github.event.comment.body, 'GEMINI') ||
-          startsWith(github.event.comment.body, '@gemini') ||
-          startsWith(github.event.comment.body, '@gemini-cli') ||
-          startsWith(github.event.comment.body, '/gemini')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
         (
-          startsWith(github.event.comment.body, 'Gemini') ||
-          startsWith(github.event.comment.body, 'GEMINI') ||
-          startsWith(github.event.comment.body, '@gemini') ||
-          startsWith(github.event.comment.body, '@gemini-cli') ||
-          startsWith(github.event.comment.body, '/gemini')
+          github.event_name == 'issue_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          (
+            startsWith(github.event.comment.body, 'Gemini') ||
+            startsWith(github.event.comment.body, 'GEMINI') ||
+            startsWith(github.event.comment.body, '@gemini') ||
+            startsWith(github.event.comment.body, '@gemini-cli') ||
+            startsWith(github.event.comment.body, '/gemini')
+          )
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          (
+            startsWith(github.event.comment.body, 'Gemini') ||
+            startsWith(github.event.comment.body, 'GEMINI') ||
+            startsWith(github.event.comment.body, '@gemini') ||
+            startsWith(github.event.comment.body, '@gemini-cli') ||
+            startsWith(github.event.comment.body, '/gemini')
+          )
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/gemini-simple.yml
+++ b/.github/workflows/gemini-simple.yml
@@ -1,6 +1,8 @@
 name: '🪐 Gemini - Simple'
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   issue_comment:
     types: [created, edited]
   pull_request_review_comment:
@@ -9,13 +11,30 @@ on:
 jobs:
   gemini:
     if: |
-      contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
       (
-        startsWith(github.event.comment.body, 'Gemini') ||
-        startsWith(github.event.comment.body, 'GEMINI') ||
-        startsWith(github.event.comment.body, '@gemini') ||
-        startsWith(github.event.comment.body, '@gemini-cli') ||
-        startsWith(github.event.comment.body, '/gemini')
+        github.event_name == 'pull_request'
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+        (
+          startsWith(github.event.comment.body, 'Gemini') ||
+          startsWith(github.event.comment.body, 'GEMINI') ||
+          startsWith(github.event.comment.body, '@gemini') ||
+          startsWith(github.event.comment.body, '@gemini-cli') ||
+          startsWith(github.event.comment.body, '/gemini')
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+        (
+          startsWith(github.event.comment.body, 'Gemini') ||
+          startsWith(github.event.comment.body, 'GEMINI') ||
+          startsWith(github.event.comment.body, '@gemini') ||
+          startsWith(github.event.comment.body, '@gemini-cli') ||
+          startsWith(github.event.comment.body, '/gemini')
+        )
       )
     runs-on: ubuntu-latest
     environment: 'Agents/Bots'
@@ -32,15 +51,46 @@ jobs:
           node-version: '20'
           check-latest: true
 
+      - name: Prepare prompt
+        id: prepare-prompt
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const eventName = context.eventName;
+            let prompt = '';
+            if (eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              const body = pr.body?.trim();
+              const description = body && body.length > 0 ? body : '_No description provided._';
+              const lines = [
+                'Gemini, please review the following pull request and provide a concise summary of the proposed changes. Highlight potential risks, call out missing tests, and note any follow-up actions.',
+                '',
+                `Repository: ${context.repo.owner}/${context.repo.repo}`,
+                `Pull Request: #${pr.number}`,
+                `Title: ${pr.title}`,
+                `Author: ${pr.user?.login ?? 'unknown'}`,
+                `URL: ${pr.html_url}`,
+                '',
+                'Pull Request Description:',
+                description,
+              ];
+              prompt = lines.join('\n');
+            } else {
+              prompt = context.payload.comment?.body ?? '';
+            }
+
+            core.setOutput('prompt', prompt);
+
       - uses: google-github-actions/run-gemini-cli@v0
         id: gemini
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_debug: 'false'
-          prompt: ${{ github.event.comment.body }}
+          prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
       - name: Post Gemini response as comment
-        if: always()
+        if: ${{ steps.gemini.outcome == 'success' }}
         uses: actions/github-script@v7
         env:
           GEMINI_SUMMARY: ${{ steps.gemini.outputs.summary }}
@@ -54,11 +104,12 @@ jobs:
               return;
             }
             const parts = [];
+            if (process.env.GEMINI_ERROR) {
+              core.warning('Gemini returned an error; skipping comment output.');
+              return;
+            }
             if (process.env.GEMINI_SUMMARY) {
               parts.push('### Gemini Response\n\n' + process.env.GEMINI_SUMMARY);
-            }
-            if (process.env.GEMINI_ERROR) {
-              parts.push('> Error\n\n```\n' + process.env.GEMINI_ERROR + '\n```');
             }
             const body = parts.join('\n\n').trim();
             if (!body) {

--- a/.github/workflows/gemini-simple.yml
+++ b/.github/workflows/gemini-simple.yml
@@ -8,37 +8,45 @@ on:
   pull_request_review_comment:
     types: [created, edited]
 
+env:
+  GEMINI_API_KEY_AVAILABLE: ${{ secrets.GEMINI_API_KEY != '' }}
+  IS_INTERNAL_PULL_REQUEST: ${{
+    github.event_name == 'pull_request' &&
+    github.event.pull_request.head.repo.full_name == github.repository
+  }}
+  IS_ISSUE_COMMENT_TRIGGER: ${{
+    github.event_name == 'issue_comment' &&
+    github.event.comment != null &&
+    contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+    (
+      startsWith(format('{0}', github.event.comment.body), 'Gemini') ||
+      startsWith(format('{0}', github.event.comment.body), 'GEMINI') ||
+      startsWith(format('{0}', github.event.comment.body), '@gemini') ||
+      startsWith(format('{0}', github.event.comment.body), '@gemini-cli') ||
+      startsWith(format('{0}', github.event.comment.body), '/gemini')
+    )
+  }}
+  IS_REVIEW_COMMENT_TRIGGER: ${{
+    github.event_name == 'pull_request_review_comment' &&
+    github.event.comment != null &&
+    contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+    (
+      startsWith(format('{0}', github.event.comment.body), 'Gemini') ||
+      startsWith(format('{0}', github.event.comment.body), 'GEMINI') ||
+      startsWith(format('{0}', github.event.comment.body), '@gemini') ||
+      startsWith(format('{0}', github.event.comment.body), '@gemini-cli') ||
+      startsWith(format('{0}', github.event.comment.body), '/gemini')
+    )
+  }}
+
 jobs:
   gemini:
-    if: |
-      secrets.GEMINI_API_KEY != '' &&
+    if: >-
+      env.GEMINI_API_KEY_AVAILABLE == 'true' &&
       (
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
-          (
-            startsWith(github.event.comment.body, 'Gemini') ||
-            startsWith(github.event.comment.body, 'GEMINI') ||
-            startsWith(github.event.comment.body, '@gemini') ||
-            startsWith(github.event.comment.body, '@gemini-cli') ||
-            startsWith(github.event.comment.body, '/gemini')
-          )
-        ) ||
-        (
-          github.event_name == 'pull_request_review_comment' &&
-          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
-          (
-            startsWith(github.event.comment.body, 'Gemini') ||
-            startsWith(github.event.comment.body, 'GEMINI') ||
-            startsWith(github.event.comment.body, '@gemini') ||
-            startsWith(github.event.comment.body, '@gemini-cli') ||
-            startsWith(github.event.comment.body, '/gemini')
-          )
-        )
+        env.IS_INTERNAL_PULL_REQUEST == 'true' ||
+        env.IS_ISSUE_COMMENT_TRIGGER == 'true' ||
+        env.IS_REVIEW_COMMENT_TRIGGER == 'true'
       )
     runs-on: ubuntu-latest
     environment: 'Agents/Bots'


### PR DESCRIPTION
## Summary
- trigger the Gemini simple workflow automatically on pull request opened, reopened, and synchronize events
- build the Gemini prompt dynamically so PR events include repository metadata and the original PR description
- suppress comment output when the Gemini run reports an error to avoid posting failure details

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68c8efc77f9c83268fba09f85e04f90e