### PR TITLE
Pin Gemini model via workflow variable

### DIFF
--- a/.github/workflows/gemini-simple.yml
+++ b/.github/workflows/gemini-simple.yml
@@ -24,6 +24,8 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    env:
+      GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}
 
     steps:
       - name: Use Node.js 20
@@ -37,6 +39,7 @@ jobs:
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_debug: 'false'
+          gemini_model: ${{ env.GEMINI_MODEL }}
           prompt: ${{ github.event.comment.body }}
 
       - name: Post Gemini response as comment


### PR DESCRIPTION
## Summary
- set a job-level GEMINI_MODEL environment variable in the Gemini workflow that defaults to gemini-2.5-flash
- pass the pinned model value to the run-gemini-cli action to ensure consistent model usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8f39d0ebc8326bf6d5b6e30a795e2