### PR TITLE
Add mock coverage for crawl endpoints

### DIFF
--- a/tests/api/test_crawl_endpoint.py
+++ b/tests/api/test_crawl_endpoint.py
@@ -1,3 +1,8 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi.responses import JSONResponse
 
 
 def test_crawl_success_with_stub(monkeypatch, client):
@@ -49,3 +54,47 @@ def test_crawl_legacy_fields(monkeypatch, client):
 def test_crawl_requires_url(client):
     resp = client.post("/crawl", json={})
     assert resp.status_code == 422
+
+
+def test_crawl_endpoint_patch_uses_simplenamespace(monkeypatch):
+    from app.api import crawl as crawl_module
+    from app.schemas.crawl import CrawlRequest, CrawlResponse
+
+    payload = CrawlRequest(url="https://example.com/path/", force_user_data=True)
+    patched = MagicMock(return_value=CrawlResponse(
+        status="success",
+        url="https://example.com/path/",
+        html="<html>patched</html>",
+    ))
+    monkeypatch.setattr(crawl_module, "crawl", patched)
+
+    response = crawl_module.crawl_endpoint(payload)
+
+    patched.assert_called_once()
+    req_obj = patched.call_args.kwargs["request"]
+    assert isinstance(req_obj, SimpleNamespace)
+    assert req_obj.url == "https://example.com/path"
+    assert req_obj.force_user_data is True
+    assert response is patched.return_value
+
+
+def test_crawl_endpoint_patch_fallback_json_response(monkeypatch):
+    from app.api import crawl as crawl_module
+    from app.schemas.crawl import CrawlRequest
+
+    payload = CrawlRequest(url="https://fallback.example.com/", force_user_data=False)
+    fallback_result = SimpleNamespace(status_code=207, json={"status": "patched"})
+    patched = MagicMock(return_value=fallback_result)
+    monkeypatch.setattr(crawl_module, "crawl", patched)
+
+    response = crawl_module.crawl_endpoint(payload)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 207
+    assert json.loads(response.body) == {"status": "patched"}
+
+    patched.assert_called_once()
+    req_obj = patched.call_args.kwargs["request"]
+    assert isinstance(req_obj, SimpleNamespace)
+    assert req_obj.url == "https://fallback.example.com"
+    assert req_obj.force_user_data is False


### PR DESCRIPTION
## Summary
- add unit tests that patch the crawl, dpd, and auspost handlers to assert SimpleNamespace payloads
- cover response passthrough and JSONResponse fallbacks when patched handlers return mocks

## Testing
- pytest tests/api/test_crawl_endpoint.py tests/api/test_dpd_endpoint.py tests/api/test_auspost_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68c9247874148326acd5b438ad14bf74