### PR TITLE
Add retry logic to camoufox fetch in CI integration workflow

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -64,8 +64,13 @@ jobs:
 
       - name: Fetch Camoufox resources
         shell: pwsh
+        env:
+          CAMOUFOX_MAX_RETRIES: 3
+          CAMOUFOX_RETRY_DELAY: 10
         run: |
-          $maxAttempts = 3
+          # Retry Camoufox fetch to mitigate rate-limit or transient network issues.
+          $maxAttempts = [int]$env:CAMOUFOX_MAX_RETRIES
+          $baseDelaySeconds = [int]$env:CAMOUFOX_RETRY_DELAY
           for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
             camoufox fetch
             if ($LASTEXITCODE -eq 0) {
@@ -78,8 +83,10 @@ jobs:
               exit $LASTEXITCODE
             }
 
-            Write-Warning "camoufox fetch failed on attempt $attempt. Retrying in 10 seconds..."
-            Start-Sleep -Seconds 10
+            $jitter = Get-Random -Minimum 0 -Maximum 5
+            $retryDelay = $baseDelaySeconds + $jitter
+            Write-Warning "camoufox fetch failed on attempt $attempt. Retrying in $retryDelay seconds..."
+            Start-Sleep -Seconds $retryDelay
           }
 
       - name: Update root certificates

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -63,7 +63,24 @@ jobs:
         run: playwright install
 
       - name: Fetch Camoufox resources
-        run: camoufox fetch
+        shell: pwsh
+        run: |
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            camoufox fetch
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "camoufox fetch succeeded on attempt $attempt."
+              break
+            }
+
+            if ($attempt -eq $maxAttempts) {
+              Write-Error "camoufox fetch failed after $maxAttempts attempts."
+              exit $LASTEXITCODE
+            }
+
+            Write-Warning "camoufox fetch failed on attempt $attempt. Retrying in 10 seconds..."
+            Start-Sleep -Seconds 10
+          }
 
       - name: Update root certificates
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- add retry logic around the `camoufox fetch` step in the integration workflow to reduce rate-limit flakes

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c929ac8a548326bc545a6900f46ddd