### PR TITLE
Ensure Gemini simple workflow checks out repository

### DIFF
--- a/.github/workflows/gemini-simple-dev.yml
+++ b/.github/workflows/gemini-simple-dev.yml
@@ -37,6 +37,12 @@ jobs:
           node-version: '20'
           check-latest: true
 
+      - name: Checkout repository
+        if: ${{ env.GEMINI_API_KEY != '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Prepare prompt
         if: ${{ env.GEMINI_API_KEY != '' }}
         id: prepare-prompt


### PR DESCRIPTION
## Summary
- checkout the repository before invoking Gemini so the agent can inspect the full workspace
- fetch the complete git history to give Gemini access to the entire codebase context

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c94bf6fa248326944b6627682140af