### PR TITLE
Add TikTok search strategy protocol

### DIFF
--- a/app/services/tiktok/interfaces.py
+++ b/app/services/tiktok/interfaces.py
@@ -1,0 +1,40 @@
+"""Protocol definitions for TikTok search services."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol, Union, runtime_checkable
+
+
+@runtime_checkable
+class TikTokSearchStrategy(Protocol):
+    """Contract for asynchronous TikTok search implementations.
+
+    Implementations encapsulate the concrete logic for performing a TikTok
+    search (network calls, parsing, retries, etc.) and return a normalized
+    payload that the rest of the application can consume.  The protocol is kept
+    intentionally small so different search backends (mock services, offline
+    fixtures, live scrapers, etc.) can be injected interchangeably wherever a
+    TikTok search capability is required.
+
+    Args:
+        query: Either a single query string or a list of query strings to
+            execute sequentially.
+        num_videos: Target number of videos to collect from the search
+            operation.
+        sort_type: TikTok sort ordering to apply when fetching results.
+        recency_days: Optional recency window identifier understood by the
+            implementation.
+
+    Returns:
+        A dictionary containing the normalized TikTok search results.
+    """
+
+    async def search(
+        self,
+        query: Union[str, List[str]],
+        num_videos: int,
+        sort_type: str,
+        recency_days: str,
+    ) -> Dict[str, Any]:
+        """Execute a TikTok search and return the structured results."""
+        ...


### PR DESCRIPTION
## Summary
- add a TikTokSearchStrategy protocol describing the asynchronous search contract
- document the interface so alternate search implementations can be injected interchangeably

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c9578ae1a08326bd38f72c0c8eea73