### PR TITLE
Adopt URL param search service without compatibility shim

### DIFF
--- a/app/services/tiktok/service.py
+++ b/app/services/tiktok/service.py
@@ -15,7 +15,7 @@ from app.schemas.tiktok.session import (
     TikTokSessionConfig,
 )
 from app.core.config import get_settings
-from app.services.tiktok.search_service import TikTokSearchService
+from app.services.tiktok.url_param_search_service import TikTokURLParamSearchService
 
 
 class TiktokService:
@@ -145,8 +145,10 @@ class TiktokService:
 
         try:
             # Execute search (search operates independently of sessions)
-            self.logger.debug("[TiktokService] Creating TikTokSearchService and executing independent search")
-            search_service = TikTokSearchService(self)
+            self.logger.debug(
+                "[TiktokService] Creating TikTokURLParamSearchService and executing independent search"
+            )
+            search_service = TikTokURLParamSearchService(self)
             result = await search_service.search(
                 query, num_videos=num_videos, sort_type=sort_type, recency_days=recency_days
             )
@@ -158,7 +160,7 @@ class TiktokService:
         except Exception as e:
             self.logger.error(f"[TiktokService] Exception in search_tiktok: {e}", exc_info=True)
             return {"error": f"Search failed: {str(e)}"}
-    # Search helpers moved to app.services.tiktok.search_service
+    # Search helpers moved to app.services.tiktok.url_param_search_service
 
     async def close_session(self, session_id: str) -> bool:
         """

--- a/app/services/tiktok/url_param_search_service.py
+++ b/app/services/tiktok/url_param_search_service.py
@@ -1,8 +1,4 @@
-"""
-TikTok search service extracted from TiktokService for clarity and reuse.
-OOP interface: TikTokSearchService(service).search(...)
-The 'service' parameter is the TiktokService instance providing settings and session helpers.
-"""
+"""URL-parameter based TikTok search service implementation."""
 
 from __future__ import annotations
 
@@ -16,7 +12,9 @@ from app.services.tiktok.abstract_search_service import AbstractTikTokSearchServ
 from app.services.tiktok.protocols import SearchContext
 
 
-class TikTokSearchService(AbstractTikTokSearchService):
+class TikTokURLParamSearchService(AbstractTikTokSearchService):
+    """Search service that builds TikTok queries using URL parameters."""
+
     def __init__(self, service: Any):
         super().__init__(service)
 


### PR DESCRIPTION
## Summary
- update `TiktokService` to instantiate `TikTokURLParamSearchService` directly instead of relying on the removed compatibility shim
- refresh the TikTok search service unit tests to target the new URL-parameter implementation

## Testing
- pytest tests/services/tiktok/test_tiktok_search_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c97a4717808326b2350c7e2e764131