### PR TITLE
Ensure Claude workflow submits PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -286,12 +286,14 @@ jobs:
 
               You must not attempt to run `git push`, create commits, or modify the repository when `CLAUDE CAN PUSH` is not `true`.
 
-              Use `gh pr comment` for pull request feedback or `gh issue comment` for issue discussions.
+              Use `gh pr comment` for incremental pull request feedback or `gh issue comment` for issue discussions.
+              When you are ready to submit your final overall review on a pull request, call `gh pr review --body "$REVIEW"` (filling `$REVIEW` with your markdown feedback).
               Use `mcp__github_inline_comment__create_inline_comment` to make inline comments on pull request diffs.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
             --allowedTools "Bash(gh pr comment:*)"
+            --allowedTools "Bash(gh pr review:*)"
             --allowedTools "Bash(gh issue comment:*)"
             --allowedTools "Bash(gh pr diff:*)"
             --allowedTools "Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- clarify the automation instructions so the Claude reviewer explicitly submits its feedback with `gh pr review --body`
- allow the workflow to execute `gh pr review` so the agent can publish the review

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c98885e5908326935fd0087107e1e1