### PR TITLE
Rename TikTok multistep search service module

### DIFF
--- a/app/services/tiktok/multistep_search_service.py
+++ b/app/services/tiktok/multistep_search_service.py
@@ -1,0 +1,24 @@
+"""Placeholder TikTok multi-step search service."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Union
+
+from app.services.tiktok.abstract_search_service import AbstractTikTokSearchService
+
+
+class TiktokMultistepSearchService(AbstractTikTokSearchService):
+    """Placeholder service inheriting from the abstract TikTok search base."""
+
+    def __init__(self, service: Any) -> None:
+        super().__init__(service)
+
+    async def search(
+        self,
+        query: Union[str, List[str]],
+        num_videos: int,
+        sort_type: str,
+        recency_days: str,
+    ) -> Dict[str, Any]:
+        """Placeholder search implementation to be provided in the future."""
+        raise NotImplementedError("TikTok multi-step search service not implemented yet.")


### PR DESCRIPTION
## Summary
- replace the previous search-bar implementation with a minimal `TiktokMultistepSearchService`
- have the placeholder inherit the abstract TikTok search service and raise `NotImplementedError` for now
- rename the module to `multistep_search_service.py` to match the placeholder service

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c989c9b78083268d8b46b9f0110224