### PR TITLE
Streamline Claude workflow prompt

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -266,29 +266,36 @@ jobs:
               ISSUE BODY: ${{ github.event.issue && github.event.issue.body || '' }}
               CLAUDE CAN PUSH: ${{ steps.edit_permissions.outputs.can_push }}
 
-              Act as a helpful GitHub assistant for the current event.
-              - For pull requests: review the changes for quality, bugs, security, and performance.
-              - For issues: help triage or answer questions.
-              - For comments or reviews: address the user's request and provide any necessary analysis.
+              Act as a helpful GitHub assistant for the event above.
+
+              Pull requests:
+              - Review the changes for quality, correctness, security, and performance concerns.
+              Issues:
+              - Help triage, reproduce, or answer the reported concern.
+              Comments or reviews:
+              - Address the explicit request and provide any necessary analysis.
 
               The repository is already checked out in the working directory.
 
-              Before making any repository changes, carefully read the triggering text above. Only modify code or push commits when a project maintainer explicitly asks you to do so (for example, comments like "@claude fix …", "@claude update …", or similar clear change requests). If the request is purely for a review or summary (for example, "@claude review"), provide feedback without editing the repository.
+              When `CLAUDE CAN PUSH` is not `true`, remain in review-only mode:
+              - Do not install dependencies (`pip install`, `npm install`, `poetry install`, `uv pip`, etc.) or run test suites—rely on CI results instead.
+              - Skip formatters, linters, or other heavy automation and focus on static analysis of the diff.
+              - Plan what to inspect before running commands so you gather diffs or files in as few tool calls as possible.
 
-              When a valid change request is made:
-              1. Check out the pull request head branch (for example with `gh pr checkout <number>`) so that any commits are applied to the contributor's branch.
-              2. Implement the minimal changes needed to satisfy the request and keep commits focused.
-              3. Run appropriate tests or linters (such as `pytest`, `pre-commit`, or other relevant commands) to validate the update.
-              4. Stage the affected files with `git add`, commit with a descriptive message, and push back to the same branch.
-              5. Leave a follow-up comment summarizing the modifications and their verification.
+              Only make repository changes when a project maintainer clearly requests edits (for example, "@claude fix …"). Provide review feedback without touching the code when the request is purely informational (for example, "@claude review").
 
-              If you are unable to push changes (for example, the pull request comes from a fork without write access as indicated by `PR HEAD IS FORK`), explain the limitation in a GitHub comment instead of failing silently.
+              When a valid change request arrives:
+              1. Check out the pull request head branch (for example, `gh pr checkout <number>`).
+              2. Implement the minimal changes needed and keep commits focused.
+              3. Run only the smallest relevant set of tests or linters to validate those edits.
+              4. Stage the files, commit with a descriptive message, and push back to the same branch.
+              5. Leave a follow-up comment summarizing the modifications and how they were verified.
 
-              You must not attempt to run `git push`, create commits, or modify the repository when `CLAUDE CAN PUSH` is not `true`.
+              If you cannot push changes (for example, the pull request comes from a fork without write access as indicated by `PR HEAD IS FORK`), explain the limitation in a comment instead of failing silently.
 
-              Always leave a top-level comment on the pull request after every analysis so the author receives your feedback. Use `gh pr comment` to post this summary (in addition to any reviews or inline comments) or `gh issue comment` for issue discussions.
-              When you are ready to submit your final overall review on a pull request, call `gh pr review --body "$REVIEW"` (filling `$REVIEW` with your markdown feedback).
-              Use `mcp__github_inline_comment__create_inline_comment` to make inline comments on pull request diffs.
+              Never attempt to create commits or run `git push` when `CLAUDE CAN PUSH` is not `true`.
+
+              After each run, leave a top-level summary comment so the author receives feedback. Use `gh pr comment` (or `gh issue comment` for issues), call `gh pr review` when submitting the final PR review, and use `mcp__github_inline_comment__create_inline_comment` for inline feedback.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
@@ -305,15 +312,15 @@ jobs:
             --allowedTools "Bash(git fetch:*)"
             --allowedTools "Bash(git pull:*)"
             --allowedTools "Bash(git config:*)"
-            --allowedTools "Bash(pytest:*)"
-            --allowedTools "Bash(python:*)"
-            --allowedTools "Bash(pip:*)"
-            --allowedTools "Bash(pip3:*)"
-            --allowedTools "Bash(pre-commit:*)"
-            --allowedTools "Bash(poetry:*)"
-            --allowedTools "Bash(uv:*)"
-            --allowedTools "Bash(npm:*)"
-            --allowedTools "Bash(yarn:*)"
-            --allowedTools "Bash(pnpm:*)"
-            --allowedTools "Bash(bun:*)"
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(pytest:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(python:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(pip:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(pip3:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(pre-commit:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(poetry:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(uv:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(npm:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(yarn:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(pnpm:*)"' || '' }}
+            ${{ steps.edit_permissions.outputs.can_push == 'true' && '--allowedTools "Bash(bun:*)"' || '' }}
             ${{ steps.edit_permissions.outputs.extra_tools }}


### PR DESCRIPTION
## Summary
- streamline the Claude workflow prompt with clearer guidance per event type and read-only expectations
- clarify when to make code changes and how to report results after edits
- remove the hard max-turn limit from the Claude invocation arguments

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c98f3195e8832695ea1dfdd531aa1c