### PR TITLE
Add reaction step to Gemini simple dev workflow

### DIFF
--- a/.github/workflows/gemini-simple-dev.yml
+++ b/.github/workflows/gemini-simple-dev.yml
@@ -26,6 +26,55 @@ jobs:
       issues: write
 
     steps:
+      - name: React with 👀 to show Gemini is running
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { eventName, payload, repo } = context;
+            const owner = repo.owner;
+            const repository = repo.repo;
+
+            async function addIssueReaction(issueNumber) {
+              if (!issueNumber) {
+                core.warning('No issue or PR number found for reaction.');
+                return;
+              }
+              await github.rest.reactions.createForIssue({
+                owner,
+                repo: repository,
+                issue_number: issueNumber,
+                content: 'eyes',
+              });
+            }
+
+            async function addCommentReaction(commentId, type) {
+              if (!commentId) {
+                core.warning(`No ${type} comment id found for reaction.`);
+                return;
+              }
+              const params = { owner, repo: repository, comment_id: commentId, content: 'eyes' };
+              if (type === 'issue') {
+                await github.rest.reactions.createForIssueComment(params);
+              } else if (type === 'review') {
+                await github.rest.reactions.createForPullRequestReviewComment(params);
+              }
+            }
+
+            try {
+              if (eventName === 'pull_request') {
+                await addIssueReaction(payload.pull_request?.number);
+              } else if (eventName === 'issue_comment') {
+                await addCommentReaction(payload.comment?.id, 'issue');
+              } else if (eventName === 'pull_request_review_comment') {
+                await addCommentReaction(payload.comment?.id, 'review');
+              } else {
+                core.warning(`Unsupported event "${eventName}" for reaction step.`);
+              }
+            } catch (error) {
+              core.warning(`Failed to add 👀 reaction: ${error.message}`);
+            }
+
       - name: Skip when Gemini API key is unavailable
         if: ${{ env.GEMINI_API_KEY == '' }}
         run: echo 'GEMINI_API_KEY is not configured. Skipping Gemini workflow.'


### PR DESCRIPTION
## Summary
- add an initial github-script step to the Gemini simple dev workflow that reacts with :eyes: when it starts
- handle pull requests, issue comments, and review comments so the trigger always gets feedback that Gemini is running

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9ff3a62e083269a3b712579730f2f