### PR TITLE
Fix conditional export of optional OpenRouter key

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,13 +82,16 @@ jobs:
           bun-version: latest
 
       - name: Export optional OpenRouter API key 2
-        if: ${{ secrets.OPENROUTER_API_KEY_2 != '' }}
+        env:
+          OPTIONAL_OPENROUTER_API_KEY_2: ${{ secrets.OPENROUTER_API_KEY_2 }}
         run: |
-          {
-            echo 'OPENROUTER_API_KEY_2<<EOF'
-            echo '${{ secrets.OPENROUTER_API_KEY_2 }}'
-            echo 'EOF'
-          } >> "$GITHUB_ENV"
+          if [ -n "${OPTIONAL_OPENROUTER_API_KEY_2}" ]; then
+            {
+              echo 'OPENROUTER_API_KEY_2<<EOF'
+              echo "${OPTIONAL_OPENROUTER_API_KEY_2}"
+              echo 'EOF'
+            } >> "$GITHUB_ENV"
+          fi
 
       - name: Start Claude Code Router
         env:


### PR DESCRIPTION
## Summary
- avoid using the secrets context in step conditions so the workflow parses correctly across events
- conditionally export the optional OpenRouter API key by checking the populated environment variable instead

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca1b3b2bf48326855a9c12f5476281