### PR TITLE
Restrict CI workflows to relevant paths

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -5,14 +5,11 @@ on:
     paths:
       - 'app/**'
       - 'tests/**'
-      - '.github/workflows/**'
-      - '.flake8'
-      - '.pre-commit-config.yaml'
-      - 'docker-compose.yml'
-      - 'Dockerfile'
       - 'requirements-test.txt'
       - 'requirements.txt'
       - 'pytest.ini'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
 
 jobs:
   unit_api:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -5,8 +5,14 @@ on:
     paths:
       - 'app/**'
       - 'tests/**'
+      - '.github/workflows/**'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
+      - 'docker-compose.yml'
+      - 'Dockerfile'
       - 'requirements-test.txt'
       - 'requirements.txt'
+      - 'pytest.ini'
 
 jobs:
   unit_api:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -2,6 +2,11 @@ name: '🧪 CI - Pull Request (Unit + Integration)'
 
 on:
   pull_request:
+    paths:
+      - 'app/**'
+      - 'tests/**'
+      - 'requirements-test.txt'
+      - 'requirements.txt'
 
 jobs:
   unit_api:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -2,6 +2,11 @@ name: '🧪 CI - Push (Unit)'
 
 on:
   push:
+    paths:
+      - 'app/**'
+      - 'tests/**'
+      - 'requirements-test.txt'
+      - 'requirements.txt'
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -5,14 +5,11 @@ on:
     paths:
       - 'app/**'
       - 'tests/**'
-      - '.github/workflows/**'
-      - '.flake8'
-      - '.pre-commit-config.yaml'
-      - 'docker-compose.yml'
-      - 'Dockerfile'
       - 'requirements-test.txt'
       - 'requirements.txt'
       - 'pytest.ini'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -5,8 +5,14 @@ on:
     paths:
       - 'app/**'
       - 'tests/**'
+      - '.github/workflows/**'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
+      - 'docker-compose.yml'
+      - 'Dockerfile'
       - 'requirements-test.txt'
       - 'requirements.txt'
+      - 'pytest.ini'
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Summary
- add path filters to the CI workflows so they only run when application, tests, or dependency files change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca235219d88326a238922f14986a76