### PR TITLE
Add 👀 reaction step to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,6 +66,73 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: React with 👀 to show Claude is running
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { eventName, payload, repo } = context;
+            const owner = repo.owner;
+            const repository = repo.repo;
+
+            async function addIssueReaction(issueNumber) {
+              if (!issueNumber) {
+                core.warning('No issue or PR number found for reaction.');
+                return;
+              }
+              await github.rest.reactions.createForIssue({
+                owner,
+                repo: repository,
+                issue_number: issueNumber,
+                content: 'eyes',
+              });
+            }
+
+            async function addCommentReaction(commentId, type) {
+              if (!commentId) {
+                core.warning(`No ${type} comment id found for reaction.`);
+                return;
+              }
+              const params = { owner, repo: repository, comment_id: commentId, content: 'eyes' };
+              if (type === 'issue') {
+                await github.rest.reactions.createForIssueComment(params);
+              } else if (type === 'review') {
+                await github.rest.reactions.createForPullRequestReviewComment(params);
+              }
+            }
+
+            async function addReviewReaction(reviewId, pullNumber) {
+              if (!reviewId || !pullNumber) {
+                core.warning('Missing review id or pull request number for reaction.');
+                return;
+              }
+              await github.rest.reactions.createForPullRequestReview({
+                owner,
+                repo: repository,
+                pull_number: pullNumber,
+                review_id: reviewId,
+                content: 'eyes',
+              });
+            }
+
+            try {
+              if (eventName === 'pull_request') {
+                await addIssueReaction(payload.pull_request?.number);
+              } else if (eventName === 'issue_comment') {
+                await addCommentReaction(payload.comment?.id, 'issue');
+              } else if (eventName === 'pull_request_review_comment') {
+                await addCommentReaction(payload.comment?.id, 'review');
+              } else if (eventName === 'pull_request_review') {
+                await addReviewReaction(payload.review?.id, payload.pull_request?.number);
+              } else if (eventName === 'issues') {
+                await addIssueReaction(payload.issue?.number);
+              } else {
+                core.warning(`Unsupported event "${eventName}" for reaction step.`);
+              }
+            } catch (error) {
+              core.warning(`Failed to add 👀 reaction: ${error.message}`);
+            }
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      reactions: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -77,7 +78,7 @@ jobs:
 
             async function addIssueReaction(issueNumber) {
               if (!issueNumber) {
-                core.warning('No issue or PR number found for reaction.');
+                console.warn('No issue or PR number found for reaction.');
                 return;
               }
               await github.rest.reactions.createForIssue({
@@ -90,7 +91,7 @@ jobs:
 
             async function addCommentReaction(commentId, type) {
               if (!commentId) {
-                core.warning(`No ${type} comment id found for reaction.`);
+                console.warn(`No ${type} comment id found for reaction.`);
                 return;
               }
               const params = { owner, repo: repository, comment_id: commentId, content: 'eyes' };
@@ -103,7 +104,7 @@ jobs:
 
             async function addReviewReaction(reviewId, pullNumber) {
               if (!reviewId || !pullNumber) {
-                core.warning('Missing review id or pull request number for reaction.');
+                console.warn('Missing review id or pull request number for reaction.');
                 return;
               }
               await github.rest.reactions.createForPullRequestReview({
@@ -127,10 +128,10 @@ jobs:
               } else if (eventName === 'issues') {
                 await addIssueReaction(payload.issue?.number);
               } else {
-                core.warning(`Unsupported event "${eventName}" for reaction step.`);
+                console.warn(`Unsupported event "${eventName}" for reaction step.`);
               }
             } catch (error) {
-              core.warning(`Failed to add 👀 reaction: ${error.message}`);
+              console.warn(`Failed to add 👀 reaction: ${error.message}`);
             }
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add a GitHub Script step to the Claude workflow to react with 👀 when it runs across supported events
- ensure pull request, issue, and review triggers all get the same eyes reaction feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca2b1e2ab48326b005094d278c3b4f