### PR TITLE
Rename direct TikTok search integration test

### DIFF
--- a/tests/integration/test_tiktok_direct_search_integration.py
+++ b/tests/integration/test_tiktok_direct_search_integration.py
@@ -7,18 +7,18 @@ pytestmark = pytest.mark.integration
 client = TestClient(app)
 
 
-class TestTikTokSearchIntegration:
-    """Integration tests for TikTok search endpoint"""
+class TestTikTokDirectSearchIntegration:
+    """Integration tests for TikTok direct search endpoint"""
 
-    def test_tiktok_search_endpoint(self):
-        """Test TikTok search endpoint with query 'gái xinh' and numVideos 10"""
+    def test_tiktok_direct_search_endpoint(self):
+        """Test TikTok direct search endpoint with query 'gái xinh' and numVideos 10"""
         # Prepare the request payload
         payload = {
             "query": "gái xinh",
             "numVideos": 10,
             "sortType": "RELEVANCE",
             "recencyDays": "ALL",
-            "strategy": "multistep"
+            "strategy": "direct"
         }
 
         # Make request to the TikTok search endpoint


### PR DESCRIPTION
## Summary
- rename the TikTok search integration test module to highlight the direct strategy
- update the test class, function, and payload to use the direct strategy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca9439277483269d0dd8c900c67eca