### PR TITLE
update aider review prompt with emojis

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -93,14 +93,13 @@ jobs:
             printf '%s\n' "You are an experienced software engineer performing a thorough code review for the GitHub pull request below."
             printf '%s\n' "This automation only provides read-only feedback, so no code changes are required."
             printf '%s\n' "Do not offer to edit files, apply patches, or ask for confirmation to make changes."
-            printf '%s\n' "Respond with exactly three sections titled **Summary**, **Issues**, and **Suggestions** and nothing else."
             printf '%s\n' ""
-            printf '%s\n' "Provide a concise review with three sections:"
-            printf '%s\n' "1. **Summary** – highlight the key changes."
-            printf '%s\n' "2. **Issues** – list potential bugs, regressions, or risks. Reference files/lines when possible."
-            printf '%s\n' "3. **Suggestions** – actionable improvements or follow-up work."
+            printf '%s\n' "Respond in Markdown beginning with the heading ### 📝 Aider Review followed by exactly three level-3 headings in this order: ### ✅ Summary, ### ⚠️ Issues, and ### 💡 Suggestions. Do not add any other sections."
+            printf '%s\n' "- **✅ Summary**: Provide 1-3 short bullet points covering the most important changes."
+            printf '%s\n' "- **⚠️ Issues**: Bullet any bugs, regressions, or risks. Reference files and line numbers when helpful. Write 'None.' if you find no issues."
+            printf '%s\n' "- **💡 Suggestions**: Offer actionable improvements, testing ideas, or follow-up work. Write 'None.' if you have no suggestions."
             printf '%s\n' ""
-            printf '%s\n' "Focus on correctness, security, performance, and maintainability. If the diff was truncated for length, call that out in your review."
+            printf '%s\n' "Keep bullets tight, prefix each bullet with a fitting emoji, and focus on correctness, security, performance, and maintainability. If the diff was truncated for length, mention it explicitly."
             printf '%s\n' ""
             printf '%s\n' "Pull request: $PR_TITLE"
             printf '%s\n' "URL: $PR_URL"
@@ -198,7 +197,11 @@ jobs:
                   return ""
 
               candidate = raw.strip()
-              match = re.search(r"(?:^|\n)(?:###\s*Summary|📝\s*Summary|\*\*\s*Summary\s*\*\*)", candidate, flags=re.IGNORECASE)
+              match = re.search(
+                  r"(?:^|\n)(?:###\s*📝\s*Aider\s+Review|###\s*✅\s*Summary|###\s*Summary|📝\s*Summary|\*\*\s*Summary\s*\*\*)",
+                  candidate,
+                  flags=re.IGNORECASE,
+              )
               if match:
                   candidate = candidate[match.start():]
 


### PR DESCRIPTION
## Summary
- update the aider review prompt to require a leading `### 📝 Aider Review` heading, emoji-labeled section headings, and emoji-prefixed bullet guidance
- extend the review extraction logic to recognize the new emoji headings when trimming aider output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb4d7b808c83268f821eee2cf88866