### PR TITLE
Use configurable OS variable with fallback for agent workflows

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -17,7 +17,7 @@ jobs:
   review:
     name: Aider Review
     if: ${{ contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.pull_request.author_association) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
           contains(github.event.issue.title, '/claude')
         )
       )
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     environment: 'Agents/Bots'
     permissions:
       contents: write

--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -18,7 +18,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini'))) ||
       (github.event_name == 'pull_request_review_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini')))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     environment: 'Agents/Bots'
     env:
       GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -52,7 +52,7 @@ jobs:
           contains(github.event.issue.title, '/opencode')
         )
       )
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     environment: 'Agents/Bots'
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- update the aider, claude, gemini, and opencode workflows to use the configured `vars.OS` runner
- add a fallback to `ubuntu-latest` when the shared OS variable is not defined

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb8082d0108326b53e1b0f5db27150