### PR TITLE
Add Sonoma Sky Alpha to OpenRouter models list

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -156,7 +156,8 @@ jobs:
                   "qwen/qwen3-coder:free",
                   "z-ai/glm-4.5-air:free",
                   "moonshotai/kimi-k2:free",
-                  "deepseek/deepseek-chat-v3.1:free"
+                  "deepseek/deepseek-chat-v3.1:free",
+                  "openrouter/sonoma-sky-alpha"
                 ],
                 "transformer": {
                   "use": [


### PR DESCRIPTION
## Summary
- add the `openrouter/sonoma-sky-alpha` model to the OpenRouter provider configuration in the Claude workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb851c1be8832699179c1e1771a952