### PR TITLE
Add pull request trigger for opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,6 +1,11 @@
 name: '🔓 Opencode'
 
 on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   issue_comment:
     types: [created, edited]
   pull_request_review_comment:
@@ -38,6 +43,28 @@ jobs:
           startsWith(github.event.review.body, '@opencode') ||
           startsWith(github.event.review.body, 'OPENCODE') ||
           startsWith(github.event.review.body, '/opencode')
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.pull_request.author_association) &&
+        (
+          (
+            github.event.pull_request.body != null &&
+            (
+              contains(github.event.pull_request.body, '@opencode') ||
+              contains(github.event.pull_request.body, 'OPENCODE') ||
+              contains(github.event.pull_request.body, '/opencode')
+            )
+          ) ||
+          (
+            github.event.pull_request.title != null &&
+            (
+              contains(github.event.pull_request.title, '@opencode') ||
+              contains(github.event.pull_request.title, 'OPENCODE') ||
+              contains(github.event.pull_request.title, '/opencode')
+            )
+          )
         )
       ) ||
       (


### PR DESCRIPTION
## Summary
- trigger the opencode workflow for opened, reopened, and synchronize pull request events
- allow pull request titles or descriptions to invoke opencode via the same keyword checks as comments and issues

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68cb85675b4c8326b41f7129d61eb626