### PR TITLE
Use configurable Gemini model in workflows

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -23,6 +23,8 @@ jobs:
       cancel-in-progress: true
     environment: 'Agents/Bots'
     timeout-minutes: 30
+    env:
+      GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}
 
     steps:
       - name: Check Gemini keys
@@ -147,7 +149,7 @@ jobs:
             export AIDER_GEMINI_API_KEY="$key"
             echo "::notice::Starting Gemini credential attempt $((index + 1)) of $max_attempts"
             if aider \
-               --model gemini/gemini-2.5-flash \
+               --model "gemini/${GEMINI_MODEL}" \
                --max-chat-history-tokens 120000 \
                --dry-run \
                --no-auto-commits \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,8 @@ jobs:
       )
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     environment: 'Agents/Bots'
+    env:
+      GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}
     permissions:
       contents: write
       pull-requests: write
@@ -180,7 +182,7 @@ jobs:
                 "api_base_url": "https://generativelanguage.googleapis.com/v1beta/models/",
                 "api_key": "${GEMINI_API_KEY}",
                 "models": [
-                  "gemini-2.5-flash"
+                  "${GEMINI_MODEL}"
                 ],
                 "transformer": {
                   "use": [
@@ -229,7 +231,7 @@ jobs:
               "default": "openrouter,z-ai/glm-4.5-air:free",
               "background": "openrouter,moonshotai/kimi-k2:free",
               "think": "openrouter,deepseek/deepseek-chat-v3.1:free",
-              "longContext": "gemini,gemini-2.5-flash",
+              "longContext": "gemini,${GEMINI_MODEL}",
               "longContextThreshold": 100000,
               "webSearch": "openrouter,moonshotai/kimi-k2:free"
             }


### PR DESCRIPTION
## Summary
- default the Aider review workflow to the GEMINI_MODEL repository variable with a gemini-2.5-flash fallback
- update the Claude workflow router configuration to reuse the GEMINI_MODEL variable instead of a hard-coded model name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb89827be483268969b2d8cc582e55