### PR TITLE
Rename runtime workflow gate variable to ACTIVE_BOTS

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -13,10 +13,15 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  ACTIVE_BOTS: ${{ vars.ACTIVE_BOTS || '["aider","claude","gemini","opencode"]' }}
+
 jobs:
   review:
     name: Aider Review
-    if: ${{ contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.pull_request.author_association) }}
+    if: >-
+      contains(fromJSON(env.ACTIVE_BOTS), 'aider') &&
+      contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.pull_request.author_association)
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,49 +16,55 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ACTIVE_BOTS: ${{ vars.ACTIVE_BOTS || '["aider","claude","gemini","opencode"]' }}
+
 jobs:
   claude:
     if: |
+      contains(fromJSON(env.ACTIVE_BOTS), 'claude') &&
       (
-        github.event_name == 'pull_request'
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
         (
-          startsWith(github.event.comment.body, '@claude') ||
-          startsWith(github.event.comment.body, 'CLAUDE') ||
-          startsWith(github.event.comment.body, '/claude')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          github.event_name == 'pull_request'
+        ) ||
         (
-          startsWith(github.event.comment.body, '@claude') ||
-          startsWith(github.event.comment.body, 'CLAUDE') ||
-          startsWith(github.event.comment.body, '/claude')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.review.author_association) &&
+          github.event_name == 'issue_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          (
+            startsWith(github.event.comment.body, '@claude') ||
+            startsWith(github.event.comment.body, 'CLAUDE') ||
+            startsWith(github.event.comment.body, '/claude')
+          )
+        ) ||
         (
-          startsWith(github.event.review.body, '@claude') ||
-          startsWith(github.event.review.body, 'CLAUDE') ||
-          startsWith(github.event.review.body, '/claude')
-        )
-      ) ||
-      (
-        github.event_name == 'issues' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.issue.author_association) &&
+          github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association) &&
+          (
+            startsWith(github.event.comment.body, '@claude') ||
+            startsWith(github.event.comment.body, 'CLAUDE') ||
+            startsWith(github.event.comment.body, '/claude')
+          )
+        ) ||
         (
-          contains(github.event.issue.body, '@claude') ||
-          contains(github.event.issue.body, 'CLAUDE') ||
-          contains(github.event.issue.body, '/claude') ||
-          contains(github.event.issue.title, '@claude') ||
-          contains(github.event.issue.title, 'CLAUDE') ||
-          contains(github.event.issue.title, '/claude')
+          github.event_name == 'pull_request_review' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.review.author_association) &&
+          (
+            startsWith(github.event.review.body, '@claude') ||
+            startsWith(github.event.review.body, 'CLAUDE') ||
+            startsWith(github.event.review.body, '/claude')
+          )
+        ) ||
+        (
+          github.event_name == 'issues' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.issue.author_association) &&
+          (
+            contains(github.event.issue.body, '@claude') ||
+            contains(github.event.issue.body, 'CLAUDE') ||
+            contains(github.event.issue.body, '/claude') ||
+            contains(github.event.issue.title, '@claude') ||
+            contains(github.event.issue.title, 'CLAUDE') ||
+            contains(github.event.issue.title, '/claude')
+          )
         )
       )
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}

--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -12,12 +12,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ACTIVE_BOTS: ${{ vars.ACTIVE_BOTS || '["aider","claude","gemini","opencode"]' }}
+
 jobs:
   gemini:
     if: >-
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini'))) ||
-      (github.event_name == 'pull_request_review_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini')))
+      contains(fromJSON(env.ACTIVE_BOTS), 'gemini') &&
+      (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'issue_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini'))) ||
+        (github.event_name == 'pull_request_review_comment' && github.event.comment != null && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER') && (startsWith(format('{0}', github.event.comment.body), 'Gemini') || startsWith(format('{0}', github.event.comment.body), 'GEMINI') || startsWith(format('{0}', github.event.comment.body), '@gemini') || startsWith(format('{0}', github.event.comment.body), '@gemini-cli') || startsWith(format('{0}', github.event.comment.body), '/gemini')))
+      )
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}
     environment: 'Agents/Bots'
     env:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -15,68 +15,74 @@ on:
   pull_request_review:
     types: [submitted, edited]
 
+env:
+  ACTIVE_BOTS: ${{ vars.ACTIVE_BOTS || '["aider","claude","gemini","opencode"]' }}
+
 jobs:
   opencode:
     if: |
+      contains(fromJSON(env.ACTIVE_BOTS), 'opencode') &&
       (
-        github.event_name == 'issue_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.comment.author_association) &&
         (
-          startsWith(github.event.comment.body, '@opencode') ||
-          startsWith(github.event.comment.body, 'OPENCODE') ||
-          startsWith(github.event.comment.body, '/opencode')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.comment.author_association) &&
-        (
-          startsWith(github.event.comment.body, '@opencode') ||
-          startsWith(github.event.comment.body, 'OPENCODE') ||
-          startsWith(github.event.comment.body, '/opencode')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.review.author_association) &&
-        (
-          startsWith(github.event.review.body, '@opencode') ||
-          startsWith(github.event.review.body, 'OPENCODE') ||
-          startsWith(github.event.review.body, '/opencode')
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.pull_request.author_association) &&
-        (
+          github.event_name == 'issue_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.comment.author_association) &&
           (
-            github.event.pull_request.body != null &&
-            (
-              contains(github.event.pull_request.body, '@opencode') ||
-              contains(github.event.pull_request.body, 'OPENCODE') ||
-              contains(github.event.pull_request.body, '/opencode')
-            )
-          ) ||
+            startsWith(github.event.comment.body, '@opencode') ||
+            startsWith(github.event.comment.body, 'OPENCODE') ||
+            startsWith(github.event.comment.body, '/opencode')
+          )
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.comment.author_association) &&
           (
-            github.event.pull_request.title != null &&
+            startsWith(github.event.comment.body, '@opencode') ||
+            startsWith(github.event.comment.body, 'OPENCODE') ||
+            startsWith(github.event.comment.body, '/opencode')
+          )
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.review.author_association) &&
+          (
+            startsWith(github.event.review.body, '@opencode') ||
+            startsWith(github.event.review.body, 'OPENCODE') ||
+            startsWith(github.event.review.body, '/opencode')
+          )
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.pull_request.author_association) &&
+          (
             (
-              contains(github.event.pull_request.title, '@opencode') ||
-              contains(github.event.pull_request.title, 'OPENCODE') ||
-              contains(github.event.pull_request.title, '/opencode')
+              github.event.pull_request.body != null &&
+              (
+                contains(github.event.pull_request.body, '@opencode') ||
+                contains(github.event.pull_request.body, 'OPENCODE') ||
+                contains(github.event.pull_request.body, '/opencode')
+              )
+            ) ||
+            (
+              github.event.pull_request.title != null &&
+              (
+                contains(github.event.pull_request.title, '@opencode') ||
+                contains(github.event.pull_request.title, 'OPENCODE') ||
+                contains(github.event.pull_request.title, '/opencode')
+              )
             )
           )
-        )
-      ) ||
-      (
-        github.event_name == 'issues' &&
-        contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.issue.author_association) &&
+        ) ||
         (
-          contains(github.event.issue.body, '@opencode') ||
-          contains(github.event.issue.body, 'OPENCODE') ||
-          contains(github.event.issue.body, '/opencode') ||
-          contains(github.event.issue.title, '@opencode') ||
-          contains(github.event.issue.title, 'OPENCODE') ||
-          contains(github.event.issue.title, '/opencode')
+          github.event_name == 'issues' &&
+          contains(fromJSON('["OWNER","COLLABORATOR","AUTHOR"]'), github.event.issue.author_association) &&
+          (
+            contains(github.event.issue.body, '@opencode') ||
+            contains(github.event.issue.body, 'OPENCODE') ||
+            contains(github.event.issue.body, '/opencode') ||
+            contains(github.event.issue.title, '@opencode') ||
+            contains(github.event.issue.title, 'OPENCODE') ||
+            contains(github.event.issue.title, '/opencode')
+          )
         )
       )
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}

--- a/docs/agent-workflow-selection.md
+++ b/docs/agent-workflow-selection.md
@@ -1,0 +1,59 @@
+# Agent workflow selection at runtime
+
+The repository now exposes a single configuration point to decide which
+agent-oriented GitHub Actions workflows should execute for an incoming event.
+The workflows affected are:
+
+- `.github/workflows/aider.yml`
+- `.github/workflows/claude.yml`
+- `.github/workflows/gemini.yml`
+- `.github/workflows/opencode.yml`
+
+## Controlling the selection
+
+1. Define or update the repository (or environment/organization) variable
+   `ACTIVE_BOTS`.
+2. Give the variable a JSON array that lists the workflows you would like to
+   execute. Use the lowercase identifiers shown below:
+
+   ```json
+   ["aider", "claude", "gemini", "opencode"]
+   ```
+
+   Any subset works, for example:
+
+   ```json
+   ["gemini", "opencode"]
+   ```
+
+3. Save the variable. No code change is required. The next workflow run will
+   read the value at runtime and only start the jobs whose identifier is
+   present in the array.
+
+If the variable is not defined, or it is left blank, all four workflows run as
+before.
+
+## Runtime behaviour
+
+- The selection is evaluated for every run. Changing the variable immediately
+  affects subsequent workflow executions.
+- A workflow that is not selected is skipped entirely, keeping the workflow
+  list tidy without consuming runner minutes.
+- The configuration works for pull requests as well as comment-triggered
+  events because the `vars` context is resolved before the job condition is
+  evaluated.
+
+## Troubleshooting
+
+- Make sure the value is valid JSON. Invalid JSON causes GitHub Actions to
+  fail while parsing the list. When in doubt, wrap the array in double quotes
+  and escape them as shown above.
+- Remember that the identifiers are lowercase (`"aider"`, `"claude"`,
+  `"gemini"`, `"opencode"`).
+- Repository variables can be set through the **Settings → Variables** UI or by
+  using the GitHub CLI:
+
+  ```bash
+  gh variable set ACTIVE_BOTS --body='["gemini","opencode"]'
+  ```
+


### PR DESCRIPTION
## Summary
- rename the shared gating variable to `ACTIVE_BOTS` across the aider, claude, gemini, and opencode workflows
- update the runtime configuration guide to reference the new `ACTIVE_BOTS` repository variable

## Testing
- not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cb8e04d97083269ce1266dcf96296a