### PR TITLE
Handle empty ACTIVE_BOTS vars in bot workflows

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -19,7 +19,7 @@ jobs:
     if: >-
       (
         vars.ACTIVE_BOTS == '' ||
-        contains(fromJSON(vars.ACTIVE_BOTS), 'aider')
+        contains(fromJSON(vars.ACTIVE_BOTS || '[]'), 'aider')
       ) &&
       contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.pull_request.author_association)
     runs-on: ${{ vars.OS || 'ubuntu-latest' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     if: |
       (
         vars.ACTIVE_BOTS == '' ||
-        contains(fromJSON(vars.ACTIVE_BOTS), 'claude')
+        contains(fromJSON(vars.ACTIVE_BOTS || '[]'), 'claude')
       ) &&
       (
         (

--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       (
         vars.ACTIVE_BOTS == '' ||
-        contains(fromJSON(vars.ACTIVE_BOTS), 'gemini')
+        contains(fromJSON(vars.ACTIVE_BOTS || '[]'), 'gemini')
       ) &&
       (
         github.event_name == 'pull_request' ||

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -20,7 +20,7 @@ jobs:
     if: |
       (
         vars.ACTIVE_BOTS == '' ||
-        contains(fromJSON(vars.ACTIVE_BOTS), 'opencode')
+        contains(fromJSON(vars.ACTIVE_BOTS || '[]'), 'opencode')
       ) &&
       (
         (


### PR DESCRIPTION
## Summary
- avoid fromJSON parsing errors when the ACTIVE_BOTS variable is unset
- default the ACTIVE_BOTS list to an empty array before checking for each bot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba22cb4708326a17a539d89db1efb