### PR TITLE
Use opencode CLI in workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -102,12 +102,13 @@ jobs:
           fetch-depth: 1
 
       - name: Install opencode CLI
-        run: curl -fsSL https://opencode.ai/install | bash
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Run opencode CLI
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           MODEL: openrouter/${{ vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
-          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
         run: |
           opencode github run --model "${MODEL}"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -101,9 +101,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run opencode
-        uses: sst/opencode/github@latest
+      - name: Install opencode CLI
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Run opencode CLI
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        with:
-          model: openrouter/tngtech/deepseek-r1t2-chimera:free
+          MODEL: openrouter/${{ vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
+          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
+        run: |
+          opencode github run --model "${MODEL}"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -126,6 +126,21 @@ jobs:
           curl -fsSL "${base_url}/package.json" -o "$runner_dir/package.json"
           curl -fsSL "${base_url}/bun.lock" -o "$runner_dir/bun.lock"
           curl -fsSL "${base_url}/index.ts" -o "$runner_dir/index.ts"
+          RUNNER_DIR_FOR_PY="$runner_dir" python - <<'PY'
+import json
+import os
+import pathlib
+
+runner_dir = pathlib.Path(os.environ["RUNNER_DIR_FOR_PY"])
+package_path = runner_dir / "package.json"
+data = json.loads(package_path.read_text())
+
+deps = data.get("devDependencies", {})
+if deps.get("@types/bun") == "catalog:":
+    deps["@types/bun"] = "^1.2.21"
+    data["devDependencies"] = deps
+    package_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
           echo "RUNNER_DIR=$runner_dir" >> "$GITHUB_ENV"
 
       - name: Install bun

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -103,12 +103,46 @@ jobs:
 
       - name: Install opencode CLI
         run: |
+          set -euo pipefail
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
-      - name: Run opencode CLI
+      - name: Determine opencode version
+        id: opencode_version
+        run: |
+          set -euo pipefail
+          version="$(opencode --version | tr -d '\n')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare opencode GitHub runner
+        env:
+          OPC_VERSION: ${{ steps.opencode_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          runner_dir=".github/opencode-runner"
+          rm -rf "$runner_dir"
+          mkdir -p "$runner_dir"
+          base_url="https://raw.githubusercontent.com/sst/opencode/v${OPC_VERSION}/github"
+          curl -fsSL "${base_url}/package.json" -o "$runner_dir/package.json"
+          curl -fsSL "${base_url}/bun.lock" -o "$runner_dir/bun.lock"
+          curl -fsSL "${base_url}/index.ts" -o "$runner_dir/index.ts"
+          echo "RUNNER_DIR=$runner_dir" >> "$GITHUB_ENV"
+
+      - name: Install bun
+        run: |
+          set -euo pipefail
+          npm install -g bun
+
+      - name: Install GitHub runner dependencies
+        working-directory: ${{ env.RUNNER_DIR }}
+        run: |
+          set -euo pipefail
+          bun install
+
+      - name: Run opencode GitHub agent
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          MODEL: openrouter/${{ vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
+          MODEL: openrouter/${{ vars.OPENROUTER_MODEL != '' && vars.OPENROUTER_MODEL || 'glm-4.5-air' }}
         run: |
-          opencode github run --model "${MODEL}"
+          set -euo pipefail
+          bun "$RUNNER_DIR/index.ts"


### PR DESCRIPTION
## Summary
- replace the opencode GitHub Action with explicit installation of the CLI
- run the CLI non-interactively and configure the model via OPENROUTER_MODEL with a glm-4.5-air fallback

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cba5f920948326b6eb2c61afe37aca