### PR TITLE
Fix dispatcher workflow env quoting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - id: filter
         shell: bash
-        run: |
-          export ACTIVE_BOTS_VAR="${{ vars.ACTIVE_BOTS || '' }}"
-          export EVENT_NAME="${{ github.event_name }}"
-          export EVENT_PAYLOAD="${{ toJSON(github.event) }}"
-          export ACTIVE_BOTS_ENV="${ACTIVE_BOTS_VAR:-}"
-          python .github/workflows/scripts/dispatcher_filter.py
+        env:
+          ACTIVE_BOTS_VAR: ${{ vars.ACTIVE_BOTS || '' }}
+          ACTIVE_BOTS_ENV: ${{ env.ACTIVE_BOTS_ENV || env.ACTIVE_BOTS || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+        run: python .github/workflows/scripts/dispatcher_filter.py
 
   aider:
     needs: determine

--- a/.github/workflows/scripts/dispatcher_filter.py
+++ b/.github/workflows/scripts/dispatcher_filter.py
@@ -109,7 +109,11 @@ def write_output(name: str, value: str) -> None:
 def decide() -> None:
     # Main logic to decide which bots run and extract target info
     active_var = (os.environ.get("ACTIVE_BOTS_VAR") or "").strip()
-    active_env = (os.environ.get("ACTIVE_BOTS_ENV") or "").strip()
+    active_env = (
+        os.environ.get("ACTIVE_BOTS_ENV")
+        or os.environ.get("ACTIVE_BOTS")
+        or ""
+    ).strip()
     active_filter = parse_active_filter(active_var or active_env)
 
     event_name = os.environ.get("EVENT_NAME") or ""


### PR DESCRIPTION
## Summary
- export dispatcher inputs via the workflow `env` block so JSON values from `ACTIVE_BOTS` no longer break the shell step
- allow the dispatcher filter script to fall back to the raw `ACTIVE_BOTS` environment variable when no workflow variable is provided

## Testing
- python -m pytest -q .github/workflows/tests/test_dispatcher_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68cbebdfccf08326bb27452b58c56339