### PR TITLE
Organize workflow tests by language

### DIFF
--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -46,5 +46,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
-      - name: Run pytest
-        run: python -m pytest -q --disable-warnings --maxfail=1 .github/workflows/tests
+      - name: Run Python workflow tests
+        run: python -m pytest -q --disable-warnings --maxfail=1 .github/workflows/tests/python

--- a/.github/workflows/tests/python/test_dispatcher_filter.py
+++ b/.github/workflows/tests/python/test_dispatcher_filter.py
@@ -6,7 +6,7 @@ import pytest
 
 
 DISPATCHER_PATH = (
-    Path(__file__).resolve().parents[1] / "scripts" / "common" / "python" / "dispatcher_filter.py"
+    Path(__file__).resolve().parents[2] / "scripts" / "common" / "python" / "dispatcher_filter.py"
 )
 
 


### PR DESCRIPTION
## Summary
- move dispatcher workflow tests into a language-specific python folder
- update the dispatcher filter test to locate the script from its new location
- run only the Python workflow tests in the CI workflow job

## Testing
- `pytest .github/workflows/tests/python -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc3afb8018832685cb2f86cff983ab