### PR TITLE
Add unit tests for GitHub workflow bot scripts

### DIFF
--- a/.github/workflows/tests/js/post_comment.test.mjs
+++ b/.github/workflows/tests/js/post_comment.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const postCommentModulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/bots/common/post_comment.js',
+);
+const { postComment } = require(postCommentModulePath);
+
+test('postComment skips when body is empty', async () => {
+  let called = false;
+  const github = {
+    rest: {
+      issues: {
+        createComment: async () => {
+          called = true;
+        },
+      },
+    },
+  };
+
+  await postComment(github, { repo: { owner: 'octo', repo: 'repo' } }, '   ', 123);
+  assert.equal(called, false, 'createComment should not be called for empty body');
+});
+
+test('postComment skips when issue number is missing', async () => {
+  let called = false;
+  const github = {
+    rest: {
+      issues: {
+        createComment: async () => {
+          called = true;
+        },
+      },
+    },
+  };
+
+  await postComment(github, { repo: { owner: 'octo', repo: 'repo' } }, 'A body', undefined);
+  assert.equal(called, false, 'createComment should not be called without issue number');
+});
+
+test('postComment posts comment when inputs are valid', async () => {
+  const calls = [];
+  const github = {
+    rest: {
+      issues: {
+        createComment: async (input) => {
+          calls.push(input);
+          return { data: { id: 1 } };
+        },
+      },
+    },
+  };
+  const context = { repo: { owner: 'octo', repo: 'repo' } };
+
+  await postComment(github, context, 'Hello world', 42);
+
+  assert.equal(calls.length, 1, 'createComment should be called once');
+  assert.deepEqual(calls[0], {
+    owner: 'octo',
+    repo: 'repo',
+    issue_number: 42,
+    body: 'Hello world',
+  });
+});
+
+test('postComment rethrows errors from GitHub client', async () => {
+  const github = {
+    rest: {
+      issues: {
+        createComment: async () => {
+          throw new Error('boom');
+        },
+      },
+    },
+  };
+  const context = { repo: { owner: 'octo', repo: 'repo' } };
+
+  await assert.rejects(
+    () => postComment(github, context, 'Hello world', 42),
+    /boom/,
+  );
+});

--- a/.github/workflows/tests/js/post_response.test.mjs
+++ b/.github/workflows/tests/js/post_response.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import esmock from 'esmock';
+
+const modulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/bots/gemini/post_response.js',
+);
+
+async function runPostResponseWithMocks({
+  payload,
+  summary,
+  error,
+  status = 'success',
+}) {
+  const infoMessages = [];
+  const failures = [];
+  const comments = [];
+
+  process.env.GITHUB_TOKEN = 'token';
+  process.env.EVENT_PAYLOAD = JSON.stringify(payload);
+  process.env.GITHUB_REPOSITORY = 'octo/scrapling';
+  process.env.GEMINI_STATUS = status;
+  if (summary !== undefined) {
+    process.env.GEMINI_SUMMARY = summary;
+  } else {
+    delete process.env.GEMINI_SUMMARY;
+  }
+  if (error !== undefined) {
+    process.env.GEMINI_ERROR = error;
+  } else {
+    delete process.env.GEMINI_ERROR;
+  }
+
+  const githubClient = {
+    rest: {
+      issues: {
+        createComment: async (options) => {
+          comments.push(options);
+        },
+      },
+    },
+  };
+
+  try {
+    await esmock(modulePath, {
+      '@actions/core': {
+        default: {
+          info: (message) => {
+            infoMessages.push(message);
+          },
+          setFailed: (message) => {
+            failures.push(message);
+          },
+        },
+      },
+      '@actions/github': {
+        context: { repo: { owner: 'octo', repo: 'scrapling' } },
+        getOctokit: () => githubClient,
+      },
+    });
+  } finally {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.EVENT_PAYLOAD;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GEMINI_STATUS;
+    delete process.env.GEMINI_SUMMARY;
+    delete process.env.GEMINI_ERROR;
+  }
+
+  return { infoMessages, failures, comments };
+}
+
+test('post_response posts combined Gemini output', async () => {
+  const { infoMessages, failures, comments } = await runPostResponseWithMocks({
+    payload: { issue: { number: 7 } },
+    summary: 'Summary text',
+    error: 'Stack trace',
+    status: 'failure',
+  });
+
+  assert.deepEqual(infoMessages, [], 'no info message should be logged on success');
+  assert.deepEqual(failures, [], 'run should succeed');
+  assert.equal(comments.length, 1, 'a comment should be created');
+  const [comment] = comments;
+  assert.equal(comment.owner, 'octo');
+  assert.equal(comment.repo, 'scrapling');
+  assert.equal(comment.issue_number, 7);
+  assert.equal(typeof comment.body, 'string', 'body should be a string');
+  assert.ok(comment.body.includes('## Gemini Review'), 'body should include review section');
+  assert.ok(comment.body.includes('Summary text'), 'body should include summary');
+  assert.ok(comment.body.includes('## Gemini Error'), 'body should include error section');
+  assert.ok(comment.body.includes('Stack trace'), 'body should include error details');
+  assert.ok(
+    comment.body.includes('Gemini CLI step ended with status: **failure**.'),
+    'body should mention non-success status',
+  );
+});
+
+test('post_response skips when issue number is unavailable', async () => {
+  const { infoMessages, comments, failures } = await runPostResponseWithMocks({
+    payload: {},
+  });
+
+  assert.deepEqual(comments, [], 'no comment should be created');
+  assert.deepEqual(failures, [], 'run should not fail when skipping');
+  assert.deepEqual(infoMessages, ['No issue or pull request number found; skipping comment.']);
+});
+
+test('post_response reports failures from GitHub API', async () => {
+  const failingClient = {
+    rest: {
+      issues: {
+        createComment: async () => {
+          throw new Error('network error');
+        },
+      },
+    },
+  };
+
+  const infoMessages = [];
+  const failures = [];
+
+  process.env.GITHUB_TOKEN = 'token';
+  process.env.EVENT_PAYLOAD = JSON.stringify({ pull_request: { number: 3 } });
+  process.env.GITHUB_REPOSITORY = 'octo/scrapling';
+  process.env.GEMINI_SUMMARY = 'Summary';
+
+  try {
+    await esmock(modulePath, {
+      '@actions/core': {
+        default: {
+          info: (message) => {
+            infoMessages.push(message);
+          },
+          setFailed: (message) => {
+            failures.push(message);
+          },
+        },
+      },
+      '@actions/github': {
+        context: { repo: { owner: 'octo', repo: 'scrapling' } },
+        getOctokit: () => failingClient,
+      },
+    });
+  } finally {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.EVENT_PAYLOAD;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GEMINI_SUMMARY;
+  }
+
+  assert.deepEqual(infoMessages, [], 'no info messages expected on failure');
+  assert.equal(failures.length, 1, 'setFailed should be called once');
+  assert.match(failures[0], /post_response failed: network error/);
+});

--- a/.github/workflows/tests/js/prepare_prompt.test.mjs
+++ b/.github/workflows/tests/js/prepare_prompt.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import esmock from 'esmock';
+
+const modulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/bots/gemini/prepare_prompt.js',
+);
+
+function buildOctokitMock({ files, commits, prData }) {
+  const listFiles = () => {};
+  const listCommits = () => {};
+  return {
+    rest: {
+      pulls: {
+        get: async () => ({ data: prData }),
+        listFiles,
+        listCommits,
+      },
+    },
+    paginate: async (fn) => {
+      if (fn === listFiles) {
+        return files;
+      }
+      if (fn === listCommits) {
+        return commits;
+      }
+      throw new Error('Unexpected paginate target');
+    },
+  };
+}
+
+test('prepare_prompt builds a rich prompt from GitHub context', async () => {
+  const setOutputs = [];
+  const warnings = [];
+  const failures = [];
+
+  const files = [
+    {
+      filename: 'src/example.js',
+      status: 'modified',
+      additions: 10,
+      deletions: 2,
+      patch: 'diff --git a/src/example.js b/src/example.js\n@@\n-' + 'a'.repeat(1600),
+    },
+    {
+      filename: 'docs/readme.md',
+      status: 'added',
+      additions: 5,
+      deletions: 0,
+      patch: null,
+    },
+  ];
+  const commits = [
+    {
+      sha: 'abcdef1234567890',
+      commit: { message: 'feat: add feature\n\nBody details' },
+    },
+  ];
+  const prData = {
+    number: 99,
+    title: 'Improve feature',
+    body: 'PR description',
+    user: { login: 'octocat' },
+    html_url: 'https://example.com/pr/99',
+  };
+
+  process.env.GITHUB_TOKEN = 'token';
+  process.env.EVENT_NAME = 'pull_request';
+  process.env.EVENT_PAYLOAD = JSON.stringify({
+    pull_request: {
+      number: 99,
+      title: 'Improve feature',
+      body: 'PR description',
+      user: { login: 'octocat' },
+      html_url: 'https://example.com/pr/99',
+    },
+    comment: {
+      body: 'Please add more tests',
+      html_url: 'https://example.com/pr/99#comment',
+    },
+  });
+  process.env.GITHUB_REPOSITORY = 'octo/scrapling';
+
+  const githubClient = buildOctokitMock({ files, commits, prData });
+
+  try {
+    await esmock(modulePath, {
+      '@actions/core': {
+        default: {
+          setOutput: (name, value) => {
+            setOutputs.push([name, value]);
+          },
+          setFailed: (message) => {
+            failures.push(message);
+          },
+          warning: (message) => {
+            warnings.push(message);
+          },
+        },
+      },
+      '@actions/github': {
+        context: { repo: { owner: 'octo', repo: 'scrapling' } },
+        getOctokit: () => githubClient,
+      },
+    });
+  } finally {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.EVENT_NAME;
+    delete process.env.EVENT_PAYLOAD;
+    delete process.env.GITHUB_REPOSITORY;
+  }
+
+  assert.deepEqual(warnings, [], 'no warnings should be emitted');
+  assert.deepEqual(failures, [], 'prepare_prompt should not fail');
+
+  const outputs = Object.fromEntries(setOutputs);
+  assert.ok(outputs.prompt, 'prompt output should be set');
+  assert.ok(
+    outputs.prompt.includes('- src/example.js (modified, +10 / -2)'),
+    'prompt should include formatted file details',
+  );
+  assert.ok(
+    outputs.prompt.includes('```diff'),
+    'prompt should include diff fenced block for patches',
+  );
+  assert.ok(
+    outputs.prompt.includes('... (patch truncated)'),
+    'prompt should mention truncated patches',
+  );
+  assert.ok(
+    outputs.prompt.includes('- abcdef1'),
+    'prompt should include abbreviated commit shas',
+  );
+  assert.ok(
+    outputs.prompt.includes('Additional request from comment:'),
+    'prompt should echo additional comment requests when present',
+  );
+  assert.equal(outputs.issue_number, '99');
+  assert.equal(outputs.issue_title, 'Improve feature');
+  assert.equal(outputs.issue_body, 'PR description');
+  assert.equal(outputs.comment_body, 'Please add more tests');
+});

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ logs/
 *.temp
 temp/
 
+# Node.js
+node_modules/
+
 # Docs
 AGENTS.md
 CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,325 @@
+{
+  "name": "scrapling-fastapi",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scrapling-fastapi",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@actions/core": "^1.10.1",
+        "@actions/github": "^6.0.0",
+        "esmock": "^2.7.3"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esmock": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.7.3.tgz",
+      "integrity": "sha512-/M/YZOjgyLaVoY6K83pwCsGE1AJQnj4S4GyXLYgi/Y79KL8EeW6WU7Rmjc89UO7jv6ec8+j34rKeWOfiLeEu0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.16.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "scrapling-fastapi",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0",
+    "esmock": "^2.7.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight Node.js dev setup for workflow script testing
- cover post_comment helper with additional scenarios
- exercise Gemini prepare_prompt and post_response scripts via mocked Octokit clients

## Testing
- node --test .github/workflows/tests/js/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc41a0ece08326888bbb99437b0d5f