### PR TITLE
Add unit tests for workflow JavaScript utilities

### DIFF
--- a/.github/workflows/tests/js/react_with_emoji.test.mjs
+++ b/.github/workflows/tests/js/react_with_emoji.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const modulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/bots/common/javascript/react_with_emoji.cjs',
+);
+const reactWithEmoji = require(modulePath);
+
+function withEventEnv(name, payload, fn) {
+  process.env.EVENT_NAME = name;
+  if (payload !== undefined) {
+    process.env.EVENT_PAYLOAD = payload;
+  } else {
+    delete process.env.EVENT_PAYLOAD;
+  }
+
+  return fn().finally(() => {
+    delete process.env.EVENT_NAME;
+    delete process.env.EVENT_PAYLOAD;
+  });
+}
+
+test('adds issue reactions for pull request events', async () => {
+  const reactions = [];
+  const warnings = [];
+  const github = {
+    rest: {
+      reactions: {
+        createForIssue: async (options) => {
+          reactions.push(options);
+        },
+      },
+    },
+  };
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'pull_request',
+    JSON.stringify({ pull_request: { number: 7 } }),
+    () => reactWithEmoji({ github, context, core, reaction: ' rocket ' }),
+  );
+
+  assert.deepEqual(reactions, [
+    { owner: 'octo', repo: 'scrapling', issue_number: 7, content: 'rocket' },
+  ]);
+  assert.deepEqual(warnings, []);
+});
+
+test('adds review comment reactions for pull request review comments', async () => {
+  const reviewReactions = [];
+  const github = {
+    rest: {
+      reactions: {
+        createForPullRequestReviewComment: async (options) => {
+          reviewReactions.push(options);
+        },
+      },
+    },
+  };
+  const warnings = [];
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'pull_request_review_comment',
+    JSON.stringify({ comment: { id: 123 } }),
+    () => reactWithEmoji({ github, context, core, reaction: 'eyes' }),
+  );
+
+  assert.deepEqual(reviewReactions, [
+    { owner: 'octo', repo: 'scrapling', comment_id: 123, content: 'eyes' },
+  ]);
+  assert.deepEqual(warnings, []);
+});
+
+test('warns and skips when comment identifiers are missing', async () => {
+  const github = {
+    rest: {
+      reactions: {
+        createForIssueComment: async () => {
+          throw new Error('should not be called');
+        },
+      },
+    },
+  };
+  const warnings = [];
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'issue_comment',
+    JSON.stringify({ comment: {} }),
+    () => reactWithEmoji({ github, context, core, reaction: '   ' }),
+  );
+
+  assert.deepEqual(warnings, ['No issue comment id found for reaction.']);
+});
+
+test('warns when event payload cannot be parsed', async () => {
+  const warnings = [];
+  const github = {
+    rest: {
+      reactions: {
+        createForIssue: async () => {
+          throw new Error('should not be called');
+        },
+      },
+    },
+  };
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'pull_request',
+    '{invalid-json',
+    () => reactWithEmoji({ github, context, core, reaction: 'eyes' }),
+  );
+
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /Failed to parse EVENT_PAYLOAD/);
+  assert.equal(warnings[1], 'No issue or PR number found for reaction.');
+});
+
+test('reports GitHub API failures and includes emoji name in warning', async () => {
+  const warnings = [];
+  const github = {
+    rest: {
+      reactions: {
+        createForIssue: async () => {
+          throw new Error('boom');
+        },
+      },
+    },
+  };
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'issues',
+    JSON.stringify({ issue: { number: 99 } }),
+    () => reactWithEmoji({ github, context, core, reaction: 'thumbs_up' }),
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0], 'Failed to add thumbs_up reaction: boom');
+});
+
+test('warns when event type is unsupported', async () => {
+  const warnings = [];
+  const github = { rest: { reactions: {} } };
+  const core = { warning: (message) => warnings.push(message) };
+  const context = { repo: { owner: 'octo', repo: 'scrapling' } };
+
+  await withEventEnv(
+    'schedule',
+    JSON.stringify({}),
+    () => reactWithEmoji({ github, context, core, reaction: 'eyes' }),
+  );
+
+  assert.deepEqual(warnings, ['Unsupported event "schedule" for reaction step.']);
+});

--- a/.github/workflows/tests/js/set_node_max_listeners.test.mjs
+++ b/.github/workflows/tests/js/set_node_max_listeners.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const require = createRequire(import.meta.url);
+const modulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/bots/common/javascript/set_node_max_listeners.cjs',
+);
+const moduleSource = await readFile(modulePath, 'utf8');
+
+function resetModuleCache() {
+  const resolved = require.resolve(modulePath);
+  delete require.cache[resolved];
+}
+
+test('raises EventEmitter defaults to the expected limit', async () => {
+  const events = require('node:events');
+  const originalDefault = events.defaultMaxListeners;
+
+  resetModuleCache();
+  try {
+    events.setMaxListeners(originalDefault);
+    require(modulePath);
+
+    const emitter = new events.EventEmitter();
+    assert.equal(emitter.getMaxListeners(), 30);
+  } finally {
+    resetModuleCache();
+    events.setMaxListeners(originalDefault);
+    if (typeof originalDefault === 'number') {
+      events.defaultMaxListeners = originalDefault;
+    }
+  }
+});
+
+test('falls back to updating defaultMaxListeners when setMaxListeners throws', async () => {
+  const calls = [];
+  const eventsMock = {
+    defaultMaxListeners: 1,
+    setMaxListeners(limit, target) {
+      calls.push([limit, target]);
+      if (arguments.length === 1) {
+        throw new TypeError('legacy runtime');
+      }
+      this.defaultMaxListeners = limit;
+    },
+  };
+
+  const context = {
+    require: (specifier) => {
+      if (specifier === 'node:events') {
+        return eventsMock;
+      }
+      throw new Error(`Unexpected require: ${specifier}`);
+    },
+    module: { exports: {} },
+    exports: {},
+    process: { env: {} },
+    console: { debug: () => {} },
+    AbortController: function MockAbortController() {
+      this.signal = { type: 'mock-signal' };
+    },
+  };
+
+  vm.runInNewContext(moduleSource, context, { filename: modulePath });
+
+  assert.equal(eventsMock.defaultMaxListeners, 30);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0][0], 30);
+  assert.equal(calls[1][0], 30);
+  assert.equal(typeof calls[1][1], 'object');
+  assert.ok(calls[1][1]);
+});
+
+test('logs debug output when ACTIONS_STEP_DEBUG is true', async () => {
+  const events = require('node:events');
+  const originalDefault = events.defaultMaxListeners;
+  const originalDebug = console.debug;
+  const messages = [];
+
+  resetModuleCache();
+  process.env.ACTIONS_STEP_DEBUG = 'true';
+  console.debug = (message) => {
+    messages.push(message);
+  };
+
+  try {
+    require(modulePath);
+    assert.deepEqual(messages, ['Gemini workflow max listeners raised to 30']);
+  } finally {
+    console.debug = originalDebug;
+    delete process.env.ACTIONS_STEP_DEBUG;
+    resetModuleCache();
+    events.setMaxListeners(originalDefault);
+    if (typeof originalDefault === 'number') {
+      events.defaultMaxListeners = originalDefault;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add thorough tests covering the workflow emoji reaction helper scenarios
- verify the Gemini max-listener bootstrapper handles debug logging and legacy fallbacks

## Testing
- node --test ".github/workflows/tests/js/*.mjs"

------
https://chatgpt.com/codex/tasks/task_e_68cccb56fd5c8326b4e8576e0e1dd0af