### PR TITLE
Remove redundant dispatcher filter tests

### DIFF
--- a/.github/workflows/tests/python/test_dispatcher_filter.py
+++ b/.github/workflows/tests/python/test_dispatcher_filter.py
@@ -44,6 +44,20 @@ def test_parse_active_filter_variants():
 
 
 @pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("claude,gemini,opencode", {"claude", "gemini", "opencode"}),
+        ("claude; gemini; opencode", {"claude", "gemini", "opencode"}),
+        ('"claude","gemini"', {"claude", "gemini"}),
+        ('  "claude" ; "gemini" , aider  ', {"claude", "gemini", "aider"}),
+        ("claude,,gemini; ; \n opencode\t", {"claude", "gemini", "opencode"}),
+    ],
+)
+def test_parse_active_filter_non_json_variants(raw_value, expected):
+    assert dispatcher_filter.parse_active_filter(raw_value) == expected
+
+
+@pytest.mark.parametrize(
     "active_filter, bot, expected",
     [
         (None, "aider", True),


### PR DESCRIPTION
## Summary
- extend dispatcher filter tests to cover semicolon-delimited and quoted ACTIVE_BOTS strings
- ensure mixed whitespace and empty tokens normalize to expected bot sets
- remove redundant top-level dispatcher filter test module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cccb2ecef483268898242cd8abbf90