### PR TITLE
Update Claude workflow instructions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -87,6 +87,7 @@ jobs:
               - For pull requests: review the changes for quality, bugs, security, and performance.
               - For issues: help triage or answer questions.
               - For comments or reviews: address the user's request and provide any necessary analysis.
+              - During reviews, provide feedback without running repository tests.
 
               The repository is already checked out in the working directory.
 


### PR DESCRIPTION
## Summary
- update Claude review workflow instructions to avoid running repository tests during reviews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccce58bc3883268894b942348d7282