### PR TITLE
Improve dispatcher summary output formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,18 +44,18 @@ jobs:
           EVENT_PAYLOAD: ${{ toJSON(github.event) }}
         run: python .github/workflows/scripts/bots/common/dispatcher_filter.py
 
-      - name: Summarize active bots filter
+      - name: Summarize dispatch decisions
         shell: bash
         env:
           ACTIVE_FILTER_JSON: ${{ steps.filter.outputs.active_filter_json }}
-        run: |
-          if [ -z "$ACTIVE_FILTER_JSON" ]; then
-            echo "Active bots filter: all (no restrictions)." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$ACTIVE_FILTER_JSON" = "[]" ]; then
-            echo "Active bots filter: none (all bots disabled)." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Active bots filter: $ACTIVE_FILTER_JSON" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          RUN_AIDER: ${{ steps.filter.outputs.run_aider }}
+          RUN_CLAUDE: ${{ steps.filter.outputs.run_claude }}
+          RUN_GEMINI: ${{ steps.filter.outputs.run_gemini }}
+          RUN_OPENCODE: ${{ steps.filter.outputs.run_opencode }}
+          TARGET_ID: ${{ steps.filter.outputs.target_id }}
+          TARGET_TYPE: ${{ steps.filter.outputs.target_type }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: python .github/workflows/scripts/bots/common/dispatcher_summary.py
 
   aider:
     needs: dispatcher

--- a/.github/workflows/scripts/bots/common/dispatcher_summary.py
+++ b/.github/workflows/scripts/bots/common/dispatcher_summary.py
@@ -1,0 +1,109 @@
+"""Generate GitHub Actions job summary for bot dispatcher decisions."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Mapping, Sequence, Tuple
+
+BOT_ENV_VARS = (
+    ("Aider", "RUN_AIDER"),
+    ("Claude", "RUN_CLAUDE"),
+    ("Gemini", "RUN_GEMINI"),
+    ("Opencode", "RUN_OPENCODE"),
+)
+
+
+def normalize_bool(value: str) -> bool:
+    """Return ``True`` when ``value`` represents a truthy dispatcher flag."""
+
+    return str(value).strip().lower() == "true"
+
+
+def summarize_active_filter(raw_filter: str) -> str:
+    """Generate the summary line describing the active bots filter."""
+
+    if not raw_filter:
+        return "Active bots filter: all (no restrictions)."
+
+    if raw_filter.strip() == "[]":
+        return "Active bots filter: none (all bots disabled)."
+
+    return f"Active bots filter: {raw_filter}"
+
+
+def build_summary_lines(
+    active_filter_json: str,
+    statuses: Sequence[Tuple[str, bool]],
+    target_type: str,
+    target_id: str,
+    event_name: str,
+) -> List[str]:
+    """Build the list of summary lines for the dispatcher job."""
+
+    lines: List[str] = [
+        summarize_active_filter(active_filter_json),
+        "",
+        "### Workflow dispatch results",
+        "",
+    ]
+
+    triggered = [name for name, should_run in statuses if should_run]
+    skipped = [name for name, should_run in statuses if not should_run]
+
+    if triggered:
+        lines.append("#### Triggered workflows")
+        lines.extend(f"- ✅ {name}" for name in triggered)
+    else:
+        lines.append("No workflows were triggered.")
+
+    if skipped:
+        if triggered or (lines and lines[-1] != ""):
+            lines.append("")
+        lines.append("#### Skipped workflows")
+        lines.extend(f"- ⛔ {name}" for name in skipped)
+
+    if target_type and target_id:
+        lines.extend(["", f"Target: {target_type} #{target_id}"])
+
+    if event_name:
+        lines.append(f"Event: {event_name}")
+
+    return lines
+
+
+def gather_statuses(env: Mapping[str, str]) -> List[Tuple[str, bool]]:
+    """Collect dispatcher statuses for each bot from ``env``."""
+
+    statuses: List[Tuple[str, bool]] = []
+    for label, var_name in BOT_ENV_VARS:
+        statuses.append((label, normalize_bool(env.get(var_name, ""))))
+    return statuses
+
+
+def write_summary(path: str, lines: Iterable[str]) -> None:
+    """Append ``lines`` to the GitHub Actions summary file when ``path`` is set."""
+
+    if not path:
+        return
+
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+def main() -> None:
+    env = os.environ
+
+    summary_lines = build_summary_lines(
+        active_filter_json=env.get("ACTIVE_FILTER_JSON", ""),
+        statuses=gather_statuses(env),
+        target_type=env.get("TARGET_TYPE", ""),
+        target_id=env.get("TARGET_ID", ""),
+        event_name=env.get("EVENT_NAME", ""),
+    )
+
+    write_summary(env.get("GITHUB_STEP_SUMMARY", ""), summary_lines)
+
+
+if __name__ == "__main__":  # pragma: no cover - direct script execution entry point
+    main()

--- a/.github/workflows/tests/python/test_dispatcher_summary.py
+++ b/.github/workflows/tests/python/test_dispatcher_summary.py
@@ -1,0 +1,133 @@
+"""Tests for the dispatcher summary GitHub Action helper script."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "bots"
+    / "common"
+    / "dispatcher_summary.py"
+)
+MODULE = runpy.run_path(str(SCRIPT_PATH))
+
+
+@pytest.mark.parametrize(
+    "raw_filter, expected",
+    [
+        ("", "Active bots filter: all (no restrictions)."),
+        ("[]", "Active bots filter: none (all bots disabled)."),
+        ("  []  ", "Active bots filter: none (all bots disabled)."),
+        (
+            "[\"aider\", \"claude\"]",
+            "Active bots filter: [\"aider\", \"claude\"]",
+        ),
+    ],
+)
+def test_summarize_active_filter_variants(raw_filter: str, expected: str) -> None:
+    summarize = MODULE["summarize_active_filter"]
+    assert summarize(raw_filter) == expected
+
+
+def test_build_summary_lines_groups_triggered_and_skipped() -> None:
+    build_lines = MODULE["build_summary_lines"]
+    lines = build_lines(
+        active_filter_json="[\"gemini\"]",
+        statuses=[
+            ("Aider", False),
+            ("Claude", True),
+            ("Gemini", True),
+            ("Opencode", False),
+        ],
+        target_type="pull_request",
+        target_id="123",
+        event_name="pull_request",
+    )
+
+    assert lines == [
+        "Active bots filter: [\"gemini\"]",
+        "",
+        "### Workflow dispatch results",
+        "",
+        "#### Triggered workflows",
+        "- ✅ Claude",
+        "- ✅ Gemini",
+        "",
+        "#### Skipped workflows",
+        "- ⛔ Aider",
+        "- ⛔ Opencode",
+        "",
+        "Target: pull_request #123",
+        "Event: pull_request",
+    ]
+
+
+def test_build_summary_lines_handles_all_skipped() -> None:
+    build_lines = MODULE["build_summary_lines"]
+    lines = build_lines(
+        active_filter_json="",
+        statuses=[
+            ("Aider", False),
+            ("Claude", False),
+        ],
+        target_type="",
+        target_id="",
+        event_name="issue_comment",
+    )
+
+    assert lines == [
+        "Active bots filter: all (no restrictions).",
+        "",
+        "### Workflow dispatch results",
+        "",
+        "No workflows were triggered.",
+        "",
+        "#### Skipped workflows",
+        "- ⛔ Aider",
+        "- ⛔ Claude",
+        "Event: issue_comment",
+    ]
+
+
+def test_main_writes_summary_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    summary_file = tmp_path / "summary.md"
+
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    monkeypatch.setenv("ACTIVE_FILTER_JSON", "")
+    monkeypatch.setenv("RUN_AIDER", "true")
+    monkeypatch.setenv("RUN_CLAUDE", "false")
+    monkeypatch.setenv("RUN_GEMINI", "false")
+    monkeypatch.setenv("RUN_OPENCODE", "true")
+    monkeypatch.setenv("TARGET_TYPE", "issue")
+    monkeypatch.setenv("TARGET_ID", "77")
+    monkeypatch.setenv("EVENT_NAME", "issues")
+
+    MODULE["main"]()
+
+    assert summary_file.read_text(encoding="utf-8") == (
+        "Active bots filter: all (no restrictions).\n"
+        "\n"
+        "### Workflow dispatch results\n"
+        "\n"
+        "#### Triggered workflows\n"
+        "- ✅ Aider\n"
+        "- ✅ Opencode\n"
+        "\n"
+        "#### Skipped workflows\n"
+        "- ⛔ Claude\n"
+        "- ⛔ Gemini\n"
+        "\n"
+        "Target: issue #77\n"
+        "Event: issues\n"
+    )
+
+
+def test_write_summary_handles_missing_path() -> None:
+    write_summary = MODULE["write_summary"]
+    # Should not raise when the path is empty and the iterator is consumed lazily
+    write_summary("", iter(["ignored"]))


### PR DESCRIPTION
## Summary
- update the dispatcher summary helper to group triggered and skipped workflows with emoji headers so GitHub Actions job summaries clearly list which bots ran
- move the dispatcher summary tests into the existing `.github/workflows/tests/python` suite and expand coverage for the new formatting behaviors

## Testing
- pip install -r requirements-test.txt
- pytest .github/workflows/tests/python/test_dispatcher_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68ccd9e8abcc83268d00374fb2856d61