### PR TITLE
Add unit tests for OpenRouter key rotation helper

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,9 +60,18 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Start Claude Code Router
+      - name: Select OpenRouter API key
+        id: select_openrouter_key
+        run: python .github/workflows/scripts/rotate_openrouter_key.py --output-selected-name openrouter_secret_name
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_API_KEY_2: ${{ secrets.OPENROUTER_API_KEY_2 }}
+          OPENROUTER_API_KEY_3: ${{ secrets.OPENROUTER_API_KEY_3 }}
+          OPENROUTER_API_KEY_4: ${{ secrets.OPENROUTER_API_KEY_4 }}
+          OPENROUTER_API_KEY_5: ${{ secrets.OPENROUTER_API_KEY_5 }}
+
+      - name: Start Claude Code Router
+        env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'z-ai/glm-4.5-air:free' }}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}

--- a/.github/workflows/docs/openrouter-key-rotation.md
+++ b/.github/workflows/docs/openrouter-key-rotation.md
@@ -1,0 +1,48 @@
+# OpenRouter API Key Rotation
+
+The `rotate_openrouter_key.py` helper script rotates between multiple
+`OPENROUTER_API_KEY` secrets before the Claude router boots.  It scans the job
+environment for variables named `OPENROUTER_API_KEY`, `OPENROUTER_API_KEY_2`,
+`OPENROUTER_API_KEY_3`, and so on.  The script chooses one value using a
+rotation seed derived from the GitHub Actions run metadata and exports it to the
+shared environment for subsequent steps.
+
+## Usage in Workflows
+
+Add a step before starting the Claude router that invokes the script:
+
+```yaml
+    - name: Select OpenRouter API key
+      id: select_openrouter_key
+      run: python .github/workflows/scripts/rotate_openrouter_key.py \
+        --output-selected-name openrouter_secret_name
+      env:
+        OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        OPENROUTER_API_KEY_2: ${{ secrets.OPENROUTER_API_KEY_2 }}
+        OPENROUTER_API_KEY_3: ${{ secrets.OPENROUTER_API_KEY_3 }}
+```
+
+The script exports the chosen key through `$GITHUB_ENV`, so later steps (such as
+`setup_router.sh`) automatically receive the rotated value without additional
+configuration.
+
+The action output `openrouter_secret_name` records which environment variable
+supplied the key, making it easier to audit runs in workflow logs.
+
+## Adding More Keys
+
+1. Create additional repository or organization secrets named
+   `OPENROUTER_API_KEY_2`, `OPENROUTER_API_KEY_3`, etc.
+2. Expose those secrets to the rotation step using the `env` block shown above.
+   Empty or undefined secrets are ignored automatically, so you can safely list
+   more slots than you currently use.
+3. Repeat the same step in any other workflow that needs rotating access to the
+   OpenRouter API.
+
+## Customizing the Rotation
+
+- Provide a custom seed by setting the `ROTATION_SEED` environment variable or
+  passing `--seed` to the script.  This is helpful when you want coordinated key
+  selection across parallel jobs.
+- Override the exported variable name via `--export-name` if the receiving step
+  expects a different environment variable.

--- a/.github/workflows/scripts/rotate_openrouter_key.py
+++ b/.github/workflows/scripts/rotate_openrouter_key.py
@@ -1,0 +1,201 @@
+"""Utility for selecting an OpenRouter API key for GitHub Actions workflows.
+
+This script inspects environment variables named ``OPENROUTER_API_KEY`` and
+optionally ``OPENROUTER_API_KEY_<n>`` (for example ``OPENROUTER_API_KEY_2``) to
+select a key in a deterministic rotating fashion.  The chosen key is appended to
+``$GITHUB_ENV`` so that later workflow steps automatically use it.  The name of
+
+the environment variable that provided the value is published (without the
+secret itself) using ``$GITHUB_OUTPUT`` for auditability.
+
+The rotation seed defaults to standard GitHub Actions run metadata so that
+re-runs will advance to the next key.  A custom seed can be provided via the
+``--seed`` flag or the ``ROTATION_SEED`` environment variable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class KeyEntry:
+    """Holds metadata about a candidate API key."""
+
+    env_name: str
+    value: str
+    order: Tuple[int, str]
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Configure and parse the command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rotate between OpenRouter API keys based on a deterministic seed."
+        )
+    )
+    parser.add_argument(
+        "--prefix",
+        default="OPENROUTER_API_KEY",
+        help="Environment variable prefix that stores the API keys.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Explicit rotation seed. Overrides environment based defaults.",
+    )
+    parser.add_argument(
+        "--export-name",
+        default=None,
+        help=(
+            "Environment variable name that will receive the selected key. "
+            "Defaults to the prefix value."
+        ),
+    )
+    parser.add_argument(
+        "--output-selected-name",
+        default="selected_key_name",
+        help=(
+            "Name of the GitHub Actions output that records which environment "
+            "variable provided the key."
+        ),
+    )
+    return parser.parse_args()
+
+
+def gather_candidate_keys(prefix: str) -> List[KeyEntry]:
+    """Collect candidate keys from the environment."""
+
+    candidates: List[KeyEntry] = []
+    prefix_with_underscore = f"{prefix}_"
+    for env_name, value in os.environ.items():
+        if env_name == prefix or env_name.startswith(prefix_with_underscore):
+            if not value:
+                continue
+            order_value = derive_order(env_name, prefix)
+            candidates.append(
+                KeyEntry(env_name=env_name, value=value, order=order_value)
+            )
+    candidates.sort(key=lambda entry: entry.order)
+    return candidates
+
+
+def derive_order(env_name: str, prefix: str) -> Tuple[int, str]:
+    """Return a tuple that ensures consistent ordering of keys."""
+
+    if env_name == prefix:
+        return (0, env_name)
+
+    suffix = env_name[len(prefix) + 1 :]
+    if suffix.isdigit():
+        return (int(suffix), env_name)
+
+    return (10_000, env_name)
+
+
+def derive_seed(user_seed: Optional[int]) -> int:
+    """Determine the rotation seed from arguments or environment variables."""
+
+    if user_seed is not None:
+        return user_seed
+
+    env_seed = os.environ.get("ROTATION_SEED")
+    if env_seed:
+        parsed = parse_seed(env_seed)
+        if parsed is not None:
+            return parsed
+
+    for candidate_env in (
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_RUN_NUMBER",
+        "GITHUB_RUN_ID",
+        "GITHUB_SHA",
+    ):
+        candidate_value = os.environ.get(candidate_env)
+        if not candidate_value:
+            continue
+        parsed = parse_seed(candidate_value)
+        if parsed is not None:
+            return parsed
+
+    return 0
+
+
+def parse_seed(raw_seed: str) -> Optional[int]:
+    """Convert a raw seed value to an integer if possible."""
+
+    try:
+        return int(raw_seed)
+    except ValueError:
+        digest = hashlib.sha256(raw_seed.encode("utf-8")).digest()
+        return int.from_bytes(digest[:8], "big")
+
+
+def select_key(candidates: Sequence[KeyEntry], seed: int) -> KeyEntry:
+    """Select a key based on the provided seed."""
+
+    if not candidates:
+        raise RuntimeError(
+            "No OpenRouter API keys were provided via the environment."
+        )
+    index = seed % len(candidates)
+    return candidates[index]
+
+
+def mask_value(value: str) -> None:
+    """Mask the selected secret so it is not shown in GitHub logs."""
+
+    print(f"::add-mask::{value}")
+
+
+def append_to_file(file_path: Optional[str], content: str) -> None:
+    """Append content to a GitHub Actions file if available."""
+
+    if not file_path:
+        print(content)
+        return
+
+    with open(file_path, "a", encoding="utf-8") as handle:
+        handle.write(f"{content}\n")
+
+
+def export_selected_key(env_name: str, value: str, export_name: str) -> None:
+    """Write the selected key value to the GitHub Actions environment file."""
+
+    github_env = os.environ.get("GITHUB_ENV")
+    append_to_file(github_env, f"{export_name}={value}")
+
+
+def publish_selected_name(output_name: str, selected_env: str) -> None:
+    """Publish the selected environment variable name as a workflow output."""
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    append_to_file(github_output, f"{output_name}={selected_env}")
+
+
+def main() -> None:
+    args = parse_arguments()
+    prefix: str = args.prefix
+    export_name: str = args.export_name or prefix
+
+    candidates = gather_candidate_keys(prefix)
+    seed = derive_seed(args.seed)
+    selected = select_key(candidates, seed)
+
+    mask_value(selected.value)
+    export_selected_key(selected.env_name, selected.value, export_name)
+    publish_selected_name(args.output_selected_name, selected.env_name)
+
+    print(
+        "Selected OpenRouter key from", selected.env_name, "->", export_name
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/tests/python/test_rotate_openrouter_key.py
+++ b/.github/workflows/tests/python/test_rotate_openrouter_key.py
@@ -1,0 +1,90 @@
+"""Tests for the OpenRouter key rotation helper script."""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib import util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "rotate_openrouter_key.py"
+)
+
+spec = util.spec_from_file_location("rotate_openrouter_key", SCRIPT_PATH)
+rotate_key = util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = rotate_key
+spec.loader.exec_module(rotate_key)  # type: ignore[union-attr]
+
+
+def _clear_openrouter_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_name in list(os.environ):
+        if env_name.startswith("OPENROUTER_API_KEY"):
+            monkeypatch.delenv(env_name, raising=False)
+
+
+def test_gather_candidate_keys_orders_by_suffix(monkeypatch):
+    """Candidate keys should be ordered base, numeric suffix, then lexicographic."""
+
+    _clear_openrouter_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "base")
+    monkeypatch.setenv("OPENROUTER_API_KEY_10", "ten")
+    monkeypatch.setenv("OPENROUTER_API_KEY_2", "two")
+    monkeypatch.setenv("OPENROUTER_API_KEY_EXTRA", "extra")
+
+    candidates = rotate_key.gather_candidate_keys("OPENROUTER_API_KEY")
+
+    ordered_names = [candidate.env_name for candidate in candidates]
+    assert ordered_names == [
+        "OPENROUTER_API_KEY",
+        "OPENROUTER_API_KEY_2",
+        "OPENROUTER_API_KEY_10",
+        "OPENROUTER_API_KEY_EXTRA",
+    ]
+
+    selected = rotate_key.select_key(candidates, seed=1)
+    assert selected.env_name == "OPENROUTER_API_KEY_2"
+
+
+def test_select_key_requires_candidates():
+    with pytest.raises(RuntimeError):
+        rotate_key.select_key([], seed=0)
+
+
+def test_main_exports_to_github_files(monkeypatch, tmp_path, capfd):
+    """Running the script writes to GitHub env/output files and masks the key."""
+
+    _clear_openrouter_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "primary")
+    monkeypatch.setenv("OPENROUTER_API_KEY_2", "secondary")
+    monkeypatch.setenv("GITHUB_ENV", str(tmp_path / "env"))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "output"))
+    monkeypatch.setenv("ROTATION_SEED", "1")
+
+    monkeypatch.setattr(sys, "argv", ["rotate_openrouter_key.py"])
+
+    rotate_key.main()
+
+    captured = capfd.readouterr().out
+    assert "::add-mask::secondary" in captured
+    assert (
+        "Selected OpenRouter key from OPENROUTER_API_KEY_2 -> OPENROUTER_API_KEY"
+        in captured
+    )
+
+    env_file = Path(os.environ["GITHUB_ENV"])
+    output_file = Path(os.environ["GITHUB_OUTPUT"])
+
+    assert env_file.read_text(encoding="utf-8").splitlines() == [
+        "OPENROUTER_API_KEY=secondary"
+    ]
+    assert output_file.read_text(encoding="utf-8").splitlines() == [
+        "selected_key_name=OPENROUTER_API_KEY_2"
+    ]
+
+    # Ensure seed env var does not leak into subsequent tests.
+    monkeypatch.delenv("ROTATION_SEED", raising=False)
+


### PR DESCRIPTION
## Summary
- add unit tests covering candidate ordering, error handling, and GitHub file exports for rotate_openrouter_key.py

## Testing
- pip install -r requirements-test.txt
- pytest .github/workflows/tests/python -q

------
https://chatgpt.com/codex/tasks/task_e_68cd3439e4e08326be56f03b7cde8979