### PR TITLE
Improve opencode CLI output formatting

### DIFF
--- a/.github/workflows/scripts/bots/opencode/build-comment.py
+++ b/.github/workflows/scripts/bots/opencode/build-comment.py
@@ -16,10 +16,31 @@ MAX_STREAM_SECTION = 2000
 def clean_stream(text: str) -> str:
     if not text:
         return ""
-    cleaned = text.replace("\r", "")
+    cleaned = _collapse_carriage_returns(text)
     cleaned = ANSI_ESCAPE_RE.sub("", cleaned)
     cleaned = CONTROL_CHAR_RE.sub("", cleaned)
     return cleaned.strip()
+
+
+def _collapse_carriage_returns(text: str) -> str:
+    text = text.replace("\r\n", "\n")
+    lines: list[str] = []
+    current: list[str] = []
+
+    for char in text:
+        if char == "\r":
+            current = []
+            continue
+        if char == "\n":
+            lines.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+
+    if current:
+        lines.append("".join(current))
+
+    return "\n".join(lines)
 
 
 

--- a/tests/bots/opencode/test_build_comment.py
+++ b/tests/bots/opencode/test_build_comment.py
@@ -1,0 +1,48 @@
+"""Tests for the opencode comment builder."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github/workflows/scripts/bots/opencode/build-comment.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("build_comment", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_review_section_omits_progress():
+    module = load_module()
+    text = (
+        "I'll review the pull request now.\n"
+        "Gathering context...\n\n"
+        "## Review Summary\n"
+        "**Findings:** The changes update comment formatting.\n"
+        "**Suggestions:** Consider adding regression tests.\n"
+        "**Confidence:** 7/10"
+    )
+
+    review, extracted = module.extract_review_section(text)
+
+    assert extracted is True
+    assert review.startswith("## Review Summary")
+    assert "**Confidence:** 7/10" in review
+    assert "Gathering context" not in review
+
+
+def test_extract_review_section_falls_back_without_markers():
+    module = load_module()
+    text = "Processing...\nAlmost done."
+
+    review, extracted = module.extract_review_section(text)
+
+    assert extracted is False
+    assert review == text


### PR DESCRIPTION
## Summary
- collapse carriage return updates from the opencode CLI so only the final review content remains in the workflow comment

## Testing
- python -m compileall .github/workflows/scripts/bots/opencode/build-comment.py

------
https://chatgpt.com/codex/tasks/task_e_68cdec38b0ec8326bee3cbac2b2eb575