### PR TITLE
Add debug prints for summary and thinking mode

### DIFF
--- a/.github/workflows/scripts/bots/opencode/build-comment.py
+++ b/.github/workflows/scripts/bots/opencode/build-comment.py
@@ -203,6 +203,10 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     metadata = load_metadata(Path(args.meta))
+    summary = metadata.get("summary")
+    thinking_mode = metadata.get("thinking_mode")
+    print(f"[debug] summary: {summary!r}")
+    print(f"[debug] thinking_mode: {thinking_mode!r}")
     stdout = read_text(Path(args.stdout))
     stderr = read_text(Path(args.stderr))
     comment = format_comment(metadata, stdout, stderr, args.exit_code)


### PR DESCRIPTION
## Summary
- add debug logging in the build-comment script to print the summary and thinking mode metadata values before formatting the comment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce39d66eb88326808974b527049932