### PR TITLE
Refine OpenCode review prompt structure

### DIFF
--- a/.github/workflows/scripts/bots/opencode/prepare_prompt.py
+++ b/.github/workflows/scripts/bots/opencode/prepare_prompt.py
@@ -104,9 +104,13 @@ def build_prompt(
         sections.append(
             dedent(
                 """
-                ### 🙋 OpenCode Review
+                ### 🛑 Operational guidelines:
+                - Treat this workflow as read-only; do not attempt to modify the repository or perform write operations.
+                - Minimize shell or tool usage; rely on reasoning over execution and only run commands when indispensable for inspecting the code.
 
                 Return a GitHub-ready review comment with the following structure:
+
+                ### 🙋 OpenCode Review
 
                 ### 👀 Findings:
                 - Call out blockers, risks, or explicitly state there are none.


### PR DESCRIPTION
## Summary
- move the operational guidelines ahead of the structured response instructions in the OpenCode review prompt
- reinforce that reviews are read-only and minimize unnecessary shell or tool usage
- ensure the required "🙋 OpenCode Review" heading remains part of the mandated response structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce73d383cc832695bfb25058f64c0e