### PR TITLE
Strip think prelude from opencode output

### DIFF
--- a/.github/workflows/tests/python/bots/opencode/test_build_comment.py
+++ b/.github/workflows/tests/python/bots/opencode/test_build_comment.py
@@ -276,3 +276,8 @@ class TestCleanStream:
 
     def test_empty(self):
         assert clean_stream("") == ""
+
+    def test_strip_leading_think_content(self):
+        text = "irrelevant details</THINK>\nFinal output"
+        cleaned = clean_stream(text)
+        assert cleaned == "Final output"


### PR DESCRIPTION
## Summary
- strip any leading </think> prelude from opencode CLI streams before composing the GitHub comment
- cover the new cleaning behavior with a dedicated unit test

## Testing
- pytest .github/workflows/tests/python/bots/opencode/test_build_comment.py

------
https://chatgpt.com/codex/tasks/task_e_68cead3ed420832693ca95513976b735