### PR TITLE
Adjust key rotation seed to vary by run

### DIFF
--- a/.github/workflows/scripts/bots/common/rotate_key/base_rotator.py
+++ b/.github/workflows/scripts/bots/common/rotate_key/base_rotator.py
@@ -137,9 +137,9 @@ class BaseKeyRotator(ABC):
         # Base seed from GitHub run metadata
         base_seed = 0
         for candidate_env in (
-            "GITHUB_RUN_ATTEMPT",
-            "GITHUB_RUN_NUMBER",
             "GITHUB_RUN_ID",
+            "GITHUB_RUN_NUMBER",
+            "GITHUB_RUN_ATTEMPT",
             "GITHUB_SHA",
         ):
             candidate_value = os.environ.get(candidate_env)


### PR DESCRIPTION
## Summary
- prefer using the GitHub run ID when deriving the base seed for key rotation so it varies between workflow runs

## Testing
- pytest .github/workflows/tests/python/rotate_key/test_rotate_openrouter_key.py


------
https://chatgpt.com/codex/tasks/task_e_68cead07c24883268b804a99a1b9e34c