### PR TITLE
Fix derive_seed entropy mixing and expand tests

### DIFF
--- a/.github/workflows/scripts/bots/common/rotate_key/base_rotator.py
+++ b/.github/workflows/scripts/bots/common/rotate_key/base_rotator.py
@@ -145,8 +145,8 @@ class BaseKeyRotator(ABC):
             candidate_value = os.environ.get(candidate_env)
             if not candidate_value:
                 continue
-            base_seed = self.parse_seed(candidate_value)
-            break
+            candidate_seed = self.parse_seed(candidate_value)
+            base_seed = (base_seed + candidate_seed) % modulus
 
         # Mix in the run attempt so retries within a run can select different keys
         attempt_value = os.environ.get("GITHUB_RUN_ATTEMPT")


### PR DESCRIPTION
## Summary
- ensure `derive_seed` accumulates entropy from all GitHub run metadata variables instead of stopping after the first value
- extend `test_base_rotator` coverage to validate metadata mixing and seed variability across run identifiers, attempts, and workflows

## Testing
- `pytest .github/workflows/tests/python/rotate_key/test_base_rotator.py`


------
https://chatgpt.com/codex/tasks/task_e_68cebae32ea88326bea6da29d2fa4757