### PR TITLE
Add heart reaction to indicate Aider workflow is running

### DIFF
--- a/.github/workflows/aider.yml
+++ b/.github/workflows/aider.yml
@@ -43,6 +43,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: React with ❤️ to show Aider is running
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { join } = require('node:path');
+            const reactWithEmoji = require(join(process.cwd(), '.github/workflows/scripts/bots/common/javascript/react_with_emoji.cjs'));
+            await reactWithEmoji({ github, context, core, reaction: 'heart' });
+
       - name: Select Gemini API key
         id: select_gemini_key
         run: >-


### PR DESCRIPTION
## Summary
- add a GitHub Script step to react with a heart after checkout in the Aider workflow so users know it is running

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cebb51cf208326b4267217c1e6ac98