### PR TITLE
Add fireworks reaction step to opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION != '' && vars.OPENCODE_VERSION || '0.10.1' }}
       EVENT_NAME: ${{ inputs.event-name }}
+      EVENT_PAYLOAD: ${{ inputs.event }}
       TARGET_ID: ${{ inputs.target-id || '' }}
       TARGET_TYPE: ${{ inputs.target-type || '' }}
       MODEL: 'openrouter/qwen/qwen3-235b-a22b:free'
@@ -40,6 +41,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: React with 🎆 to show Opencode is running
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { join } = require('node:path');
+            const reactWithEmoji = require(join(process.cwd(), '.github/workflows/scripts/bots/common/javascript/react_with_emoji.cjs'));
+            await reactWithEmoji({ github, context, core, reaction: 'hooray' });
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- add the event payload to the opencode job environment so the reaction script can target the right item
- react with a 🎆 (hooray) emoji after checkout to show the Opencode workflow is running

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cebb7ab32c832683597ac29140b1fe