### PR TITLE
Document parallel pytest execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,17 @@ For detailed instructions on running the application, see [RUN.md](RUN.md).
 
 ## Testing
 
+Tests run in parallel by default via [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/latest/) (configured with `-n auto`).
 Run all tests:
 
 ```bash
 python -m pytest
+```
+
+Run the suite serially if needed:
+
+```bash
+python -m pytest -n 0
 ```
 
 Unit tests only:


### PR DESCRIPTION
## Summary
- document that pytest runs in parallel by default
- provide instructions for running tests serially when needed

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cf6ca060208326bad3e68479ddead8