### PR TITLE
chore: cache dependencies in ci workflows

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -40,11 +40,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-test.txt
-            **/requirements*.txt
+
+      - name: Cache pip downloads
+        if: runner.os != 'Windows' || env.ACT != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ hashFiles('requirements.txt', 'requirements-test.txt', '**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python }}-
+            ${{ runner.os }}-pip-
 
       - name: Use preinstalled deps (ACT Windows)
         if: runner.os == 'Windows' && env.ACT == 'true'
@@ -56,8 +63,30 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
         run: playwright install
+
+      - name: Cache Camoufox resources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/camoufox
+            ~/.local/share/camoufox
+            ~/Library/Application Support/Camoufox
+            ~\AppData\Local\Camoufox
+          key: ${{ runner.os }}-camoufox-${{ hashFiles('requirements.txt', 'requirements-test.txt', '**/requirements*.txt', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-camoufox-
 
       - name: Fetch Camoufox resources
         shell: pwsh

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -42,6 +42,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Cache pip downloads
+        id: cache-pip
         if: runner.os != 'Windows' || env.ACT != 'true'
         uses: actions/cache@v4
         with:
@@ -52,6 +53,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python }}-
             ${{ runner.os }}-pip-
+
+      - name: Log pip cache result
+        if: runner.os != 'Windows' || env.ACT != 'true'
+        run: echo "Cache hit for pip downloads: ${{ steps.cache-pip.outputs.cache-hit }}"
 
       - name: Use preinstalled deps (ACT Windows)
         if: runner.os == 'Windows' && env.ACT == 'true'
@@ -64,19 +69,24 @@ jobs:
           pip install -r requirements.txt -r requirements-test.txt
 
       - name: Cache Playwright browsers
+        id: cache-playwright
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ matrix.python }}-${{ hashFiles('requirements.txt', 'requirements-test.txt', '**/requirements*.txt', 'package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
+
+      - name: Log Playwright cache result
+        run: echo "Cache hit for Playwright browsers: ${{ steps.cache-playwright.outputs.cache-hit }}"
 
       - name: Install Playwright browsers
         run: playwright install
 
       - name: Cache Camoufox resources
+        id: cache-camoufox
         uses: actions/cache@v4
         with:
           path: |
@@ -87,6 +97,9 @@ jobs:
           key: ${{ runner.os }}-camoufox-${{ hashFiles('requirements.txt', 'requirements-test.txt', '**/requirements*.txt', 'package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-camoufox-
+
+      - name: Log Camoufox cache result
+        run: echo "Cache hit for Camoufox resources: ${{ steps.cache-camoufox.outputs.cache-hit }}"
 
       - name: Fetch Camoufox resources
         shell: pwsh

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -29,11 +29,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-test.txt
-            **/requirements*.txt
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ hashFiles('requirements.txt', 'requirements-test.txt', '**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python }}-
+            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -31,6 +31,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Cache pip downloads
+        id: cache-pip
         uses: actions/cache@v4
         with:
           path: |
@@ -40,6 +41,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python }}-
             ${{ runner.os }}-pip-
+
+      - name: Log pip cache result
+        run: echo "Cache hit for pip downloads: ${{ steps.cache-pip.outputs.cache-hit }}"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -45,6 +45,7 @@ jobs:
           python-version: "3.10.8"
 
       - name: Cache pip downloads
+        id: cache-pip
         uses: actions/cache@v4
         with:
           path: |
@@ -54,6 +55,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-3.10.8-
             ${{ runner.os }}-pip-
+
+      - name: Log pip cache result
+        run: echo "Cache hit for pip downloads: ${{ steps.cache-pip.outputs.cache-hit }}"
 
       - name: Install Python dependencies
         run: |
@@ -69,12 +73,16 @@ jobs:
           node-version: "20"
 
       - name: Cache npm cache
+        id: cache-npm
         uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', '.github/workflows/tests/js/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+
+      - name: Log npm cache result
+        run: echo "Cache hit for npm cache: ${{ steps.cache-npm.outputs.cache-hit }}"
 
       - name: Install Node.js dependencies
         run: npm ci

--- a/.github/workflows/ci-workflows.yml
+++ b/.github/workflows/ci-workflows.yml
@@ -43,10 +43,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10.8"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-test.txt
-            **/requirements*.txt
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-3.10.8-${{ hashFiles('requirements-test.txt', '**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.10.8-
+            ${{ runner.os }}-pip-
 
       - name: Install Python dependencies
         run: |
@@ -60,7 +67,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+
+      - name: Cache npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', '.github/workflows/tests/js/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
       - name: Install Node.js dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- add actions/cache@v4 steps to reuse Python dependency downloads across CI workflows
- preserve Playwright browsers between runs to accelerate integration testing
- cache npm downloads for workflow tests to shorten Node-based checks
- cache Camoufox resources to reduce repeated fetch time in integration workflow

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68cfda5261f08326a8a71a5e7cee6795