### PR TITLE
Add package markers for integration test modules

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite package marker to enable absolute imports in test modules."""
+

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+"""Integration test package marker for absolute imports."""
+

--- a/tests/integration/crawl/__init__.py
+++ b/tests/integration/crawl/__init__.py
@@ -1,0 +1,2 @@
+"""Crawl integration test package marker."""
+


### PR DESCRIPTION
## Summary
- add `__init__` modules so the `tests` package can be imported by integration tests
- ensure crawl integration subpackage resolves absolute imports during test discovery

## Testing
- pytest tests/integration --maxfail=1 --disable-warnings -q *(fails: live crawl assertions and missing Camoufox assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b088f4288326a3a55ba6bfe1e1e5