### PR TITLE
Redirect root endpoint to API docs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    
+
     @app.get("/", include_in_schema=False)
     async def redirect_to_docs() -> RedirectResponse:
         return RedirectResponse(url="/docs", status_code=307)

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from app.api import router as api_router
 from app.core.config import get_settings
 from app.core.logging import setup_logger
@@ -39,6 +39,11 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    
+    @app.get("/", include_in_schema=False)
+    async def redirect_to_docs() -> RedirectResponse:
+        return RedirectResponse(url="/docs", status_code=307)
+
     app.include_router(api_router)
 
     @app.exception_handler(RequestValidationError)

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -21,3 +21,10 @@ def test_routes_include_expected_paths():
 
     missing = EXPECTED_PATHS - registered_paths
     assert not missing, f"Missing expected routes: {sorted(missing)}"
+
+
+def test_root_redirects_to_docs(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/docs"


### PR DESCRIPTION
## Summary
- add a root endpoint that redirects users to the FastAPI docs
- import `RedirectResponse` to perform the redirect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10a7fd27883269c7236fbd081704e