### PR TITLE
Update DPD wait selector

### DIFF
--- a/app/services/crawler/dpd.py
+++ b/app/services/crawler/dpd.py
@@ -37,7 +37,7 @@ class DPDCrawler:
         url = f"{DPD_BASE}/{encoded_code}"
         return CrawlRequest(
             url=url,
-            wait_for_selector="div.delivery-info",
+            wait_for_selector="tra-tracking-table",
             wait_for_selector_state="visible",
             network_idle=True,
             force_headful=dpd_request.force_headful,


### PR DESCRIPTION
## Summary
- update the DPD crawler to wait for the new `tra-tracking-table` element when loading tracking pages

## Testing
- pytest tests/api/test_dpd_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d1102d8b8883269bd69eca865cf020