### PR TITLE
ci: pin bun version for claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Bun runtime
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: v1.2.11
 
       - name: Start Claude Code Router
         env:


### PR DESCRIPTION
## Summary
- pin the Claude GitHub Action's Bun runtime to v1.2.11 to avoid unexpected updates

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d12dd8e78883268c0ce9a0748ecf02