### PR TITLE
fix: harden camoufox mute prefs

### DIFF
--- a/app/services/common/browser/camoufox.py
+++ b/app/services/common/browser/camoufox.py
@@ -101,7 +101,14 @@ class CamoufoxArgsBuilder:
         if force_mute:
             existing_prefs = additional_args.get("firefox_user_prefs")
             firefox_prefs = dict(existing_prefs) if isinstance(existing_prefs, dict) else {}
-            firefox_prefs.setdefault("dom.audiochannel.mutedByDefault", True)
+
+            # Firefox honours multiple knobs for audio output. Setting all of them
+            # ensures audio stays muted even when autoplay/media policies change
+            # across releases.
+            firefox_prefs["dom.audiochannel.mutedByDefault"] = True
+            firefox_prefs["media.default_volume"] = 0.0
+            firefox_prefs["media.volume_scale"] = 0.0
+
             additional_args["firefox_user_prefs"] = firefox_prefs
 
         # Do NOT pass `solve_cloudflare` via additional_args.

--- a/tests/services/browser/test_camoufox_args_builder.py
+++ b/tests/services/browser/test_camoufox_args_builder.py
@@ -158,9 +158,9 @@ class TestCamoufoxArgsBuilder:
         # Assert
         prefs = additional_args.get('firefox_user_prefs')
         assert prefs is not None
-        assert 'media.volume_scale' not in prefs
-        assert 'media.default_volume' not in prefs
         assert prefs['dom.audiochannel.mutedByDefault'] is True
+        assert prefs['media.default_volume'] == 0.0
+        assert prefs['media.volume_scale'] == 0.0
 
     def test_build_respects_config_default(self, builder, mock_request, mock_settings, mock_caps):
         # Arrange
@@ -186,9 +186,9 @@ class TestCamoufoxArgsBuilder:
         # Assert
         prefs = additional_args.get('firefox_user_prefs')
         assert prefs is not None
-        assert 'media.volume_scale' not in prefs
-        assert 'media.default_volume' not in prefs
         assert prefs['dom.audiochannel.mutedByDefault'] is True
+        assert prefs['media.default_volume'] == 0.0
+        assert prefs['media.volume_scale'] == 0.0
 
     def test_build_no_camoufox_user_data_dir(self, builder, mock_request, mock_settings, mock_caps):
         # Arrange
@@ -203,6 +203,8 @@ class TestCamoufoxArgsBuilder:
         prefs = additional_args.get('firefox_user_prefs')
         assert prefs is not None
         assert prefs['dom.audiochannel.mutedByDefault'] is True
+        assert prefs['media.default_volume'] == 0.0
+        assert prefs['media.volume_scale'] == 0.0
 
     def test_build_user_data_dir_permission_error(self, builder, mock_request, mock_settings, mock_caps):
         # Arrange
@@ -221,3 +223,5 @@ class TestCamoufoxArgsBuilder:
                 prefs = additional_args.get('firefox_user_prefs')
                 assert prefs is not None
                 assert prefs['dom.audiochannel.mutedByDefault'] is True
+                assert prefs['media.default_volume'] == 0.0
+                assert prefs['media.volume_scale'] == 0.0


### PR DESCRIPTION
## Summary
- ensure Camoufox builds always write the Firefox mute preferences needed for reliable silence
- update the Camoufox args builder tests to cover the new preference set

## Testing
- pytest tests/services/browser/test_camoufox_args_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68d133d498908326a1a43cfc858bf421