### PR TITLE
chore: adjust claude workflow versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,8 +78,6 @@ jobs:
 
       - name: Setup Bun runtime
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: v1.2.11
 
       - name: Start Claude Code Router
         env:
@@ -90,7 +88,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.8
+        uses: anthropics/claude-code-action@v1.0.7
         env:
           ANTHROPIC_BASE_URL: http://localhost:3456
           ANTHROPIC_API_KEY: "dummy"


### PR DESCRIPTION
## Summary
- remove the explicit Bun runtime version pin from the Claude workflow
- pin anthropics/claude-code-action to v1.0.7 for the Claude workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d13744965883269d587ad93252e52e