### PR TITLE
chore: use floating claude action version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.7
+        uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: http://localhost:3456
           ANTHROPIC_API_KEY: "dummy"


### PR DESCRIPTION
## Summary
- update the Claude workflow to use the floating `anthropics/claude-code-action@v1`

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d139d36ecc8326a7339726a4a4e59d