### PR TITLE
fix: always mute camoufox audio

### DIFF
--- a/app/services/common/browser/camoufox.py
+++ b/app/services/common/browser/camoufox.py
@@ -81,22 +81,10 @@ class CamoufoxArgsBuilder:
         if getattr(settings, "camoufox_virtual_display", None):
             additional_args["virtual_display"] = settings.camoufox_virtual_display
 
-        default_mute = bool(getattr(settings, "camoufox_force_mute_audio_default", True))
-        request_flag = getattr(payload, "force_mute_audio", None)
-
-        if request_flag is None:
-            force_mute = default_mute
-        else:
-            force_mute = bool(request_flag)
-
-        if not force_mute:
-            force_mute = bool(
-                getattr(settings, "camoufox_runtime_force_mute_audio", False)
-            )
-        if not force_mute:
-            force_mute = bool(getattr(settings, "_camoufox_force_mute_audio", False))
-        if not force_mute and default_mute:
-            force_mute = True
+        # Camoufox must remain muted across all endpoints regardless of payload
+        # or runtime settings. Enforce the Firefox preference explicitly instead
+        # of relying on configurable flags.
+        force_mute = True
 
         if force_mute:
             existing_prefs = additional_args.get("firefox_user_prefs")

--- a/tests/services/browser/test_camoufox_args_builder.py
+++ b/tests/services/browser/test_camoufox_args_builder.py
@@ -172,7 +172,8 @@ class TestCamoufoxArgsBuilder:
 
         # Assert
         prefs = additional_args.get('firefox_user_prefs')
-        assert prefs is None
+        assert prefs is not None
+        assert prefs['dom.audiochannel.mutedByDefault'] is True
 
     def test_build_force_mute_from_settings(self, builder, mock_request, mock_settings, mock_caps):
         # Arrange


### PR DESCRIPTION
## Summary
- force Camoufox arguments builder to always enable the Firefox muted-by-default preference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d13f2d882c83269ef6a9be7fa2d215