### PR TITLE
chore: update opencode model selection

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -33,8 +33,8 @@ jobs:
       EVENT_PAYLOAD: ${{ inputs.event }}
       TARGET_ID: ${{ inputs.target-id || '' }}
       TARGET_TYPE: ${{ inputs.target-type || '' }}
-      # MODEL: 'openrouter/qwen/qwen3-235b-a22b:free'
-      MODEL: 'openrouter/x-ai/grok-4-fast:free'
+      MODEL: 'openrouter/qwen/qwen3-235b-a22b:free'
+      # MODEL: 'openrouter/x-ai/grok-4-fast:free'
     concurrency:
       group: opencode-${{ github.workflow }}-${{ inputs.event-name }}-${{ inputs.target-id != '' && inputs.target-id || github.run_id }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- set the Opencode workflow to use the Qwen 235B free model by default
- retain the Grok model reference as a commented alternative

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d365dae50083268b9426cabfbb255f