### PR TITLE
docs: ban project .venv usage, prefer system Python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ AI Agent Development Guidelines for Scrapling FastAPI Project
 ## Development Commands & Patterns
 
 ### Environment Setup
-- `python -m venv .venv` then `.venv/Scripts/activate` (or `source .venv/bin/activate`)
+- **DO NOT** create or use .venv virtual environments
+- Use the system's direct Python interpreter
 - `pip install -r requirements.txt` for runtime deps; add `-r requirements-test.txt` for testing
 
 ### Running the Application
@@ -125,6 +126,7 @@ AI Agent Development Guidelines for Scrapling FastAPI Project
 4. **REQUIRED** to use type hints throughout
 5. **MANDATORY** schema consistency with existing patterns
 6. **ESSENTIAL** to clean up intermediate files after implementation
+7. **FORBIDDEN** to create or use .venv virtual environments - use system Python directly
 
 ## Governance
 


### PR DESCRIPTION
Update AGENTS.md to explicitly prohibit creating or using .venv
virtual environments and to require using the system Python.
Clarify environment setup by removing prior example that showed
creating/activating a .venv and instead state that developers must
use the system's direct Python. Add a new governance rule marking
.venv usage as forbidden and reinforce the system Python requirement.

This prevents inconsistent virtualenv usage across contributors,
avoids activation/script differences between platforms, and aligns
development setup with project policies for reproducible builds.