### PR TITLE
feat: add MCP server configs and unit test marker

### DIFF
--- a/.kilocode/mcp.json
+++ b/.kilocode/mcp.json
@@ -1,0 +1,28 @@
+﻿{
+  "mcpServers": {
+    "brave-search": {
+      "command": "node",
+      "args": [
+        "--import=dotenv/config",
+        "node_modules/@modelcontextprotocol/server-brave-search/dist/index.js"
+      ],
+      "env": {
+        "DOTENV_CONFIG_PATH": ".claude/mcp.env"
+      },
+      "alwaysAllow": [
+        "brave_web_search"
+      ]
+    },
+    "Scrapling Docs": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://gitmcp.io/D4Vinci/Scrapling"
+      ],
+      "alwaysAllow": [
+        "search_Scrapling_documentation",
+        "fetch_Scrapling_documentation"
+      ]
+    }
+  }
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short --strict-markers -n auto
 markers =
+    unit: unit tests (no network/browser dependencies)
     integration: real network/browser integration tests
     asyncio: mark a test as requiring the asyncio event loop
     log_level: specify the logging level for a test


### PR DESCRIPTION
Add initial .kilocode/mcp.json defining two MCP servers:
- brave-search: run via node with dotenv config and always allow
  brave_web_search capability.
- Scrapling Docs: run via npx mcp-remote to the Scrapling MCP URL
  and always allow two Scrapling documentation capabilities.

Add a pytest.ini marker "unit" to label tests that do not require
network or browser dependencies.

These changes enable local MCP server discovery and control over
test selection for faster, offline-friendly test runs.