### PR TITLE
feat(ci): add resilient Camoufox fetch and call in CI

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,15 +1,15 @@
-name: '🧪 CI - Push (Unit)'
+name: "🧪 CI - Push (Unit)"
 
 on:
   push:
     paths:
-      - 'app/**'
-      - 'tests/**'
-      - 'requirements-test.txt'
-      - 'requirements.txt'
-      - 'pytest.ini'
-      - '.flake8'
-      - '.pre-commit-config.yaml'
+      - "app/**"
+      - "tests/**"
+      - "requirements-test.txt"
+      - "requirements.txt"
+      - "pytest.ini"
+      - ".flake8"
+      - ".pre-commit-config.yaml"
   workflow_call:
 
 jobs:
@@ -51,9 +51,21 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-test.txt
 
+      - name: Fetch Camoufox resources
+        env:
+          CAMOUFOX_MAX_RETRIES: 3
+          CAMOUFOX_RETRY_DELAY: 10
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            pwsh -ExecutionPolicy Bypass -File ./.github/workflows/scripts/ci/fetch_camoufox.ps1
+          else
+            chmod +x ./.github/workflows/scripts/ci/fetch_camoufox.sh
+            ./.github/workflows/scripts/ci/fetch_camoufox.sh
+          fi
+        shell: bash
+
       - name: Lint
         run: flake8 app/ tests/
 
       - name: Run tests (skip integration)
         run: python -m pytest -q -m "not integration" --disable-warnings --maxfail=1
-

--- a/.github/workflows/scripts/ci/fetch_camoufox.sh
+++ b/.github/workflows/scripts/ci/fetch_camoufox.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Function to resolve integer value or use default
+resolve_int_or_default() {
+    local value="$1"
+    local default="$2"
+    
+    if [ -n "$value" ] && [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$value"
+    else
+        echo "$default"
+    fi
+}
+
+# Get parameters with defaults
+max_retries=$(resolve_int_or_default "$1" "$(resolve_int_or_default "$CAMOUFOX_MAX_RETRIES" "3")")
+retry_delay=$(resolve_int_or_default "$2" "$(resolve_int_or_default "$CAMOUFOX_RETRY_DELAY" "10")")
+
+for ((attempt=1; attempt<=max_retries; attempt++)); do
+    camoufox fetch
+    if [ $? -eq 0 ]; then
+        echo "camoufox fetch succeeded on attempt $attempt."
+        exit 0
+    fi
+    
+    if [ $attempt -eq $max_retries ]; then
+        echo "camoufox fetch failed after $max_retries attempts." >&2
+        exit 1
+    fi
+    
+    # Add jitter (0-4 seconds)
+    jitter=$((RANDOM % 5))
+    retry_delay_seconds=$((retry_delay + jitter))
+    echo "camoufox fetch failed on attempt $attempt. Retrying in $retry_delay_seconds seconds..." >&2
+    sleep $retry_delay_seconds
+done


### PR DESCRIPTION
Add a POSIX bash script to fetch Camou resources with configurable
 behavior and jitter. The script validates numeric inputs or
falls back to environment defaults (CAMOUFOX_RETRIES,
CAMOUFOX_RETRY), retries the `camoufox fetch` command up to the
configured number of attempts, and adds 0–4s random jitter to each
retry sleep to reduce thundering herd failures. It exits non-zero after
exhausting retries.

Invoke the fetch script from the CI push workflow. Add a cross-platform
step that runs the PowerShell helper on Windows and the new bash
script on other runners, exporting default retry environment variables.
Also normalize YAML string quoting in the workflow file. These changes
ensure CI reliably obtains Camoufox dependencies and reduces transient
CI failures due to temporary fetch errors.